### PR TITLE
Update rules_kotlin to v1.5.0-beta-3.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,7 +59,11 @@ load("//build/com_google_truth:repo.bzl", "com_google_truth_artifact_dict")
 
 # @io_bazel_rules_kotlin
 
-load("//build/io_bazel_rules_kotlin:repo.bzl", "rules_kotlin_repo")
+load(
+    "//build/io_bazel_rules_kotlin:repo.bzl",
+    "IO_BAZEL_RULES_KOTLIN_OVERRIDE_TARGETS",
+    "rules_kotlin_repo",
+)
 
 rules_kotlin_repo()
 
@@ -100,9 +104,9 @@ load(
 
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "82262ff4223c5fda6fb7ff8bd63db8131b51b413d26eb49e3131037e79e324af",
-    strip_prefix = "rules_jvm_external-3.2",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/3.2.zip",
+    sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
+    strip_prefix = "rules_jvm_external-4.1",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -115,6 +119,8 @@ MAVEN_ARTIFACTS = artifacts.list_to_dict(
 
 MAVEN_ARTIFACTS.update(com_google_truth_artifact_dict(version = "1.0.1"))
 
+# kotlinx.coroutines version should be compatible with Kotlin release used by
+# rules_kotlin. See https://kotlinlang.org/docs/releases.html#release-details.
 MAVEN_ARTIFACTS.update(kotlinx_coroutines_artifact_dict(version = "1.4.3"))
 
 # Add Maven artifacts or override versions (e.g. those pulled in by gRPC Kotlin
@@ -129,6 +135,10 @@ MAVEN_ARTIFACTS.update({
     "junit:junit": "4.13",
     "org.conscrypt:conscrypt-openjdk-uber": "2.5.2",
     "org.mockito.kotlin:mockito-kotlin": "3.2.0",
+
+    # For grpc-kotlin. This should be a version that is compatible with the
+    # Kotlin release used by rules_kotlin.
+    "com.squareup:kotlinpoet": "1.8.0",
 })
 
 maven_install(
@@ -136,6 +146,7 @@ maven_install(
     fetch_sources = True,
     generate_compat_repositories = True,
     override_targets = dict(
+        IO_BAZEL_RULES_KOTLIN_OVERRIDE_TARGETS.items() +
         IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS.items() +
         IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS.items(),
     ),

--- a/build/io_bazel_rules_kotlin/deps.bzl
+++ b/build/io_bazel_rules_kotlin/deps.bzl
@@ -14,7 +14,8 @@
 
 """Repository rules/macros for rules_kotlin dependencies."""
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_register_toolchains")
 
 def rules_kotlin_deps():
     kotlin_repositories()

--- a/build/io_bazel_rules_kotlin/repo.bzl
+++ b/build/io_bazel_rules_kotlin/repo.bzl
@@ -19,6 +19,14 @@ See https://github.com/bazelbuild/rules_kotlin
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+IO_BAZEL_RULES_KOTLIN_OVERRIDE_TARGETS = {
+    "org.jetbrains.kotlin:kotlin.stdlib": "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+    "org.jetbrains.kotlin:kotlin.stdlib-jdk7": "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk7",
+    "org.jetbrains.kotlin:kotlin.stdlib-jdk8": "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
+    "org.jetbrains.kotlin:kotlin.reflect": "@com_github_jetbrains_kotlin//:kotlin-reflect",
+    "org.jetbrains.kotlin:kotlin.test": "@com_github_jetbrains_kotlin//:kotlin-test",
+}
+
 def _rules_kotlin_repo(version, sha256):
     http_archive(
         name = "io_bazel_rules_kotlin",
@@ -27,17 +35,7 @@ def _rules_kotlin_repo(version, sha256):
     )
 
 def rules_kotlin_repo():
-    # Import rules_android to work around known bug in rules_kotlin v1.5.0-beta-2.
-    # See https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.5.0-beta-2
-    if "rules_android" not in native.existing_rules():
-        http_archive(
-            name = "rules_android",
-            urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-            sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-            strip_prefix = "rules_android-0.1.1",
-        )
-
     _rules_kotlin_repo(
-        version = "v1.5.0-beta-2",
-        sha256 = "e4185409c787c18f332ae83a73827aab6e77058a48ffee0cac01123408cbc89a",
+        version = "v1.5.0-beta-3",
+        sha256 = "58edd86f0f3c5b959c54e656b8e7eb0b0becabd412465c37a2078693c2571f7f",
     )

--- a/imports/kotlin/kotlin/reflect/jvm/BUILD.bazel
+++ b/imports/kotlin/kotlin/reflect/jvm/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "jvm",
-    actual = "@maven//:org_jetbrains_kotlin_kotlin_reflect",
+    actual = "@com_github_jetbrains_kotlin//:kotlin-reflect",
 )

--- a/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(
     default_testonly = True,

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(
     default_testonly = True,

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/throttler/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/throttler/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/common/throttler/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/throttler/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/common/BUILD.bazel
@@ -1,6 +1,6 @@
 # Common functionality for Google Cloud (gcloud) APIs.
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
@@ -1,6 +1,6 @@
 # Blob/object storage specifics for Google Cloud Storage (GCS).
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/BUILD.bazel
@@ -1,6 +1,6 @@
 # Database specifics for Google Cloud Spanner.
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing/macros.bzl
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing/macros.bzl
@@ -14,7 +14,7 @@
 
 """Macros for Spanner test targets."""
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 def spanner_emulator_test(name, data = [], **kwargs):
     kt_jvm_test(

--- a/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -1,6 +1,6 @@
 # Blob/object storage.
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/forwarded/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/forwarded/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(
     default_testonly = True,

--- a/src/test/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "BytesTest",

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "SecurityProviderTest",

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "ChannelShutdownHookTest",

--- a/src/test/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "IdentifiersTest",

--- a/src/test/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "TestClockWithNamedInstantsTest",

--- a/src/test/kotlin/org/wfanet/measurement/common/throttler/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/throttler/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "AdaptiveThrottlerTest",

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "GcsStorageClientTest",

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/spanner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "SpannerStructsTest",

--- a/src/test/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "FileSystemStorageClientTest",


### PR DESCRIPTION
This also applies fixes to avoid having multiple versions of Kotlin standard libraries. See world-federation-of-advertisers/cross-media-measurement#158.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/19)
<!-- Reviewable:end -->
