### PR TITLE
Add kt_jvm_proto_library BUILD rule.

### DIFF
--- a/build/com_google_protobuf/repo.bzl
+++ b/build/com_google_protobuf/repo.bzl
@@ -18,13 +18,14 @@ Repository rules/macros for Protobuf.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+COM_GOOGLE_PROTOBUF_VERSION = "3.17.3"
+
+_URL_TEMPLATE = "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protobuf-all-%s.tar.gz"
+
 def com_google_protobuf_repo():
-    if "com_google_protobuf" not in native.existing_rules():
-        http_archive(
-            name = "platforms",
-            sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
-            urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
-                "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
-            ],
-        )
+    http_archive(
+        name = "com_google_protobuf",
+        sha256 = "77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2",
+        strip_prefix = "protobuf-" + COM_GOOGLE_PROTOBUF_VERSION,
+        url = _URL_TEMPLATE % (COM_GOOGLE_PROTOBUF_VERSION, COM_GOOGLE_PROTOBUF_VERSION),
+    )

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -33,6 +33,7 @@ load(
 load("//build/com_google_truth:repo.bzl", "com_google_truth_artifact_dict")
 load("//build/kotlinx_coroutines:repo.bzl", "kotlinx_coroutines_artifact_dict")
 load("//build/maven:artifacts.bzl", "artifacts")
+load("//build/com_google_protobuf:repo.bzl", "COM_GOOGLE_PROTOBUF_VERSION")
 
 def common_jvm_maven_artifacts():
     """
@@ -67,6 +68,10 @@ def common_jvm_maven_artifacts():
         # For grpc-kotlin. This should be a version that is compatible with the
         # Kotlin release used by rules_kotlin.
         "com.squareup:kotlinpoet": "1.8.0",
+
+        # For kt_jvm_proto_library.
+        # The version must match that in //build/com_google_protobuf/repo.bzl.
+        "com.google.protobuf:protobuf-kotlin": COM_GOOGLE_PROTOBUF_VERSION,
     })
 
     return artifacts.dict_to_list(maven_artifacts)

--- a/build/kt_jvm_proto_library.bzl
+++ b/build/kt_jvm_proto_library.bzl
@@ -1,0 +1,149 @@
+# Copyright 2021 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Provides kt_jvm_proto_library to generate Kotlin protos.
+"""
+
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+def _get_real_short_path(file):
+    """Returns the correct short path file name to be used by protoc."""
+    short_path = file.short_path
+    if short_path.startswith("../"):
+        second_slash = short_path.index("/", 3)
+        short_path = short_path[second_slash + 1:]
+
+    # TODO: see if ProtoInfo.proto_source_root can be used instead.
+    virtual_imports = "_virtual_imports/"
+    if virtual_imports in short_path:
+        short_path = short_path.split(virtual_imports)[1].split("/", 1)[1]
+    return short_path
+
+def _run_protoc(ctx, output_dir):
+    """Executes protoc to generate Kotlin files."""
+    proto_info = ctx.attr.proto_dep[ProtoInfo]
+    descriptor_sets = proto_info.transitive_descriptor_sets
+    transitive_descriptor_set = depset(transitive = [descriptor_sets])
+    proto_sources = [_get_real_short_path(file) for file in proto_info.direct_sources]
+
+    protoc_args = ctx.actions.args()
+    protoc_args.set_param_file_format("multiline")
+    protoc_args.use_param_file("@%s")
+    protoc_args.add("--kotlin_out=" + output_dir.path)
+    protoc_args.add_joined(
+        transitive_descriptor_set,
+        join_with = ctx.configuration.host_path_separator,
+        format_joined = "--descriptor_set_in=%s",
+    )
+    protoc_args.add_all(proto_sources)
+    ctx.actions.run(
+        inputs = depset(transitive = [transitive_descriptor_set]),
+        outputs = [output_dir],
+        executable = ctx.executable._protoc,
+        arguments = [protoc_args],
+        progress_message = "Generating Kotlin protos for " + ctx.label.name,
+    )
+
+def _build_srcjar(ctx, input_dir, source_jar):
+    """Bundles .kt files into a srcjar."""
+    args = ctx.actions.args()
+    args.add("c")
+    args.add(source_jar.path)
+    args.add_all(depset([input_dir]))
+    ctx.actions.run_shell(
+        outputs = [source_jar],
+        inputs = [input_dir],
+        tools = [ctx.executable._zipper],
+        arguments = [args],
+        command = "{zipper} $@".format(zipper = ctx.executable._zipper.path),
+        mnemonic = "KtProtoSrcJar",
+        progress_message = "Generating Kotlin proto srcjar for " + ctx.label.name,
+    )
+
+def _kt_jvm_proto_library_helper_impl(ctx):
+    """Implementation of _kt_jvm_proto_library_helper rule."""
+    name = ctx.label.name
+
+    gen_src_dir_name = "%s/ktproto" % name
+    gen_src_dir = ctx.actions.declare_directory(gen_src_dir_name)
+    source_jar = ctx.actions.declare_file("%s.srcjar" % name)
+
+    _run_protoc(ctx, gen_src_dir)
+    _build_srcjar(ctx, gen_src_dir, source_jar)
+
+    java_info = ctx.attr.java_proto_dep[JavaInfo]
+    default_info = DefaultInfo(files = depset([source_jar, gen_src_dir]))
+
+    return [java_info, default_info]
+
+_kt_jvm_proto_library_helper = rule(
+    attrs = dict(
+        java_proto_dep = attr.label(providers = [JavaInfo]),
+        proto_dep = attr.label(providers = [ProtoInfo]),
+        _zipper = attr.label(
+            # TODO: use bin/jar from java toolchain instead of zipper.
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/zip:zipper"),
+            allow_files = True,
+        ),
+        _protoc = attr.label(
+            default = Label("@com_google_protobuf//:protoc"),
+            cfg = "host",
+            executable = True,
+        ),
+    ),
+    fragments = ["java"],
+    provides = [JavaInfo],  # Hack -- this shouldn't be needed
+    implementation = _kt_jvm_proto_library_helper_impl,
+)
+
+def kt_jvm_proto_library(name, srcs = None, deps = None, **kwargs):
+    """Generates Kotlin code for a protocol buffer library.
+
+    For standard attributes, see:
+      https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes
+
+    Args:
+      name: A name for the target
+      srcs: Exactly one proto_library target to generate Kotlin APIs for
+      deps: Exactly one java_proto_library target for srcs[0]
+      **kwargs: other args to pass to the ultimate kt_jvm_library target
+    """
+    srcs = srcs or []
+    deps = deps or []
+
+    if len(srcs) != 1:
+        fail("Expected exactly one src", "srcs")
+
+    if len(deps) != 1:
+        fail("Expected exactly one dep", "deps")
+
+    generated_kt_name = name + "_DO_NOT_DEPEND_generated_kt"
+    generated_kt_label = ":" + generated_kt_name
+    _kt_jvm_proto_library_helper(
+        name = generated_kt_name,
+        java_proto_dep = deps[0],
+        proto_dep = srcs[0],
+        visibility = ["//visibility:private"],
+    )
+
+    kt_jvm_library(
+        name = name,
+        srcs = [generated_kt_label],
+        # TODO: add Bazel rule in protobuf instead of relying on Maven
+        deps = deps + ["@maven//:com_google_protobuf_protobuf_kotlin"],
+        **kwargs
+    )

--- a/src/test/kotlin/org/wfanet/bazel/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/bazel/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "KtJvmProtoLibraryTest",
+    srcs = ["KtJvmProtoLibraryTest.kt"],
+    test_class = "org.wfanet.bazel.KtJvmProtoLibraryTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/org/junit",
+        "//imports/kotlin/kotlin/test",
+        "//src/test/proto/wfa/measurement/common:fake_message_kt_jvm_proto",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/bazel/KtJvmProtoLibraryTest.kt
+++ b/src/test/kotlin/org/wfanet/bazel/KtJvmProtoLibraryTest.kt
@@ -1,0 +1,34 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.bazel
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.FakeMessageKt.submessage
+import org.wfanet.measurement.common.fakeMessage
+
+@RunWith(JUnit4::class)
+class KtJvmProtoLibraryTest {
+
+  @Test
+  fun `Kotlin features are present`() {
+    fakeMessage {
+      int64Field = 12345L
+      submessages += submessage { stringField = "abc" }
+      submessages += submessage { int64Field = 67890L }
+    }
+  }
+}

--- a/src/test/proto/wfa/measurement/common/BUILD.bazel
+++ b/src/test/proto/wfa/measurement/common/BUILD.bazel
@@ -1,7 +1,26 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//build:kt_jvm_proto_library.bzl", "kt_jvm_proto_library")
 load("//build:macros.bzl", "kt_jvm_grpc_and_java_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "fake_message_proto",
+    srcs = ["fake_message.proto"],
+    strip_import_prefix = "/src/test/proto",
+)
+
+java_proto_library(
+    name = "fake_message_java_proto",
+    deps = [":fake_message_proto"],
+)
+
+kt_jvm_proto_library(
+    name = "fake_message_kt_jvm_proto",
+    srcs = [":fake_message_proto"],
+    deps = [":fake_message_java_proto"],
+)
 
 proto_library(
     name = "fake_service_proto",

--- a/src/test/proto/wfa/measurement/common/fake_message.proto
+++ b/src/test/proto/wfa/measurement/common/fake_message.proto
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.common;
+
+option java_package = "org.wfanet.measurement.common";
+option java_multiple_files = true;
+
+message FakeMessage {
+  int64 int64_field = 1;
+  string string_field = 2;
+  repeated Submessage submessages = 3;
+
+  message Submessage {
+    int64 int64_field = 1;
+    string string_field = 2;
+  }
+}


### PR DESCRIPTION
This should eventually be owned by rules_kotlin (https://github.com/bazelbuild/rules_kotlin).

This initial PR contains some minor hacks that future PRs will address before attempting to move this over to rules_kotlin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/26)
<!-- Reviewable:end -->
