### PR TITLE
Migrate Signatures to common-jvm from consent-signaling-client

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -3,6 +3,19 @@ load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 package(default_visibility = ["//visibility:public"])
 
 kt_jvm_library(
+    name = "invalid_signature_exception",
+    srcs = ["InvalidSignatureException.kt"],
+    deps = [
+    ],
+)
+
+kt_jvm_library(
+    name = "hashing",
+    srcs = ["Hashing.kt"],
+    deps = ["@wfa_common_jvm//imports/java/com/google/protobuf"],
+)
+
+kt_jvm_library(
     name = "security_provider",
     srcs = ["SecurityProvider.kt"],
     deps = [
@@ -13,15 +26,19 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "signatures",
+    srcs = ["Signatures.kt"],
+    deps = [
+        "//imports/java/com/google/protobuf",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:invalid_signature_exception",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
+    ],
+)
+
+kt_jvm_library(
     name = "signing_certs",
     srcs = ["SigningCerts.kt"],
     deps = [
         ":security_provider",
     ],
-)
-
-kt_jvm_library(
-    name = "hashing",
-    srcs = ["Hashing.kt"],
-    deps = ["@wfa_common_jvm//imports/java/com/google/protobuf"],
 )

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/InvalidSignatureException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/InvalidSignatureException.kt
@@ -1,0 +1,21 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+/**
+ * Indicates that there is a problem matching data to a signature. Either the signature is invalid
+ * for the data or can't be found at all.
+ */
+class InvalidSignatureException(message: String) : Exception(message)

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/Signatures.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/Signatures.kt
@@ -1,0 +1,91 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.protobuf.ByteString
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.cert.X509Certificate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * Signs [data] using this [PrivateKey].
+ *
+ * @param certificate the [X509Certificate] that can be used to verify the signature
+ */
+fun PrivateKey.sign(certificate: X509Certificate, data: ByteString): ByteString {
+  val signer = Signature.getInstance(certificate.sigAlgName, jceProvider)
+  signer.initSign(this)
+  signer.update(data.asReadOnlyByteBuffer())
+  return ByteString.copyFrom(signer.sign())
+}
+
+/**
+ * Signs [data] using this [PrivateKey]. Takes in a [Flow<ByteString>] for signing streaming data.
+ *
+ * Note that the deferred output (the signature) will only be ready when the Flow has been fully
+ * collected.
+ *
+ * @param certificate the [X509Certificate] that can be used to verify the signature
+ */
+fun PrivateKey.signFlow(
+  certificate: X509Certificate,
+  data: Flow<ByteString>
+): Pair<Flow<ByteString>, Deferred<ByteString>> {
+  val signer = Signature.getInstance(certificate.sigAlgName, jceProvider)
+  val deferredSig = CompletableDeferred<ByteString>()
+  signer.initSign(this)
+  val outFlow =
+    data.onEach { signer.update(it.asReadOnlyByteBuffer()) }.onCompletion {
+      deferredSig.complete(ByteString.copyFrom(signer.sign()))
+    }
+  return outFlow to deferredSig
+}
+
+/**
+ * Verifies that the [signature] for [data] was signed by the entity represented by this
+ * [X509Certificate].
+ */
+fun X509Certificate.verifySignature(data: ByteString, signature: ByteString): Boolean {
+  val verifier = Signature.getInstance(this.sigAlgName, jceProvider)
+  verifier.initVerify(this)
+  verifier.update(data.asReadOnlyByteBuffer())
+  return verifier.verify(signature.toByteArray())
+}
+
+/**
+ * Returns a flow containing the original values of Flow [data] and verifies that the [signature]
+ * for [data] was signed by the entity represented by this [X509Certificate].
+ *
+ * The output is the downstream Flow of [data]. If [data] is found to not match [signature] upon
+ * collecting the flow, the flow will throw an [InvalidSignatureException].
+ */
+fun X509Certificate.verifySignedFlow(
+  data: Flow<ByteString>,
+  signature: ByteString,
+): Flow<ByteString> {
+  val verifier = Signature.getInstance(this.sigAlgName, jceProvider)
+
+  verifier.initVerify(this)
+  return data.onEach { verifier.update(it.asReadOnlyByteBuffer()) }.onCompletion {
+    if (it == null && !verifier.verify(signature.toByteArray())) {
+      throw InvalidSignatureException("Signature is invalid")
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -13,3 +13,13 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common",
     ],
 )
+
+kt_jvm_library(
+    name = "verified_storage_extensions",
+    srcs = ["VerifiedStorageExtensions.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:invalid_signature_exception",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
+        "//src/main/kotlin/org/wfanet/measurement/storage:client",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/storage/VerifiedStorageExtensions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/VerifiedStorageExtensions.kt
@@ -1,0 +1,55 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.storage
+
+import com.google.protobuf.ByteString
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.common.crypto.signFlow
+import org.wfanet.measurement.common.crypto.verifySignedFlow
+import org.wfanet.measurement.storage.StorageClient.Blob
+
+/**
+ * Stub for verified read function. Intended to be used in combination with a the other party's
+ * provided [X509Certificate], this validates that the data in the blob has been generated (or at
+ * least signed as valid) by the other party.
+ *
+ * Note that the validation happens in a separate thread and is non-blocking, but will throw a
+ * terminal error if it fails.
+ */
+suspend fun Blob.verifiedRead(
+  cert: X509Certificate,
+  signature: ByteString,
+  bufferSize: Int
+): Flow<ByteString> {
+  return cert.verifySignedFlow(this.read(bufferSize), signature)
+}
+
+/**
+ * Stub for verified write function. Intended to be used in combination with a provided [PrivateKey]
+ * , this creates a signature in shared storage for the written blob that can be verified by the
+ * other party using a pre-provided [X509Certificate].
+ */
+suspend fun StorageClient.createSignedBlob(
+  blobKey: String,
+  content: Flow<ByteString>,
+  privateKey: PrivateKey,
+  cert: X509Certificate
+): Pair<Blob, ByteString> {
+  val (contentFlow, deferredSig) = privateKey.signFlow(cert, content)
+  val resultBlob = this.createBlob(blobKey = blobKey, content = contentFlow)
+  return resultBlob to deferredSig.await()
+}

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -1,6 +1,20 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
+    name = "HashingTest",
+    srcs = ["HashingTest.kt"],
+    test_class = "org.wfanet.measurement.common.crypto.HashingTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/protobuf",
+        "//imports/java/org/junit",
+        "//imports/kotlin/kotlin/test",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:hashing",
+    ],
+)
+
+kt_jvm_test(
     name = "SecurityProviderTest",
     srcs = ["SecurityProviderTest.kt"],
     test_class = "org.wfanet.measurement.common.crypto.SecurityProviderTest",
@@ -16,15 +30,17 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
-    name = "HashingTest",
-    srcs = ["HashingTest.kt"],
-    test_class = "org.wfanet.measurement.common.crypto.HashingTest",
+    name = "SignaturesTest",
+    srcs = ["SignaturesTest.kt"],
+    test_class = "org.wfanet.measurement.common.crypto.SignaturesTest",
     deps = [
         "//imports/java/com/google/common/truth",
-        "//imports/java/com/google/protobuf",
         "//imports/java/org/junit",
         "//imports/kotlin/kotlin/test",
+        "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common",
-        "//src/main/kotlin/org/wfanet/measurement/common/crypto:hashing",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/SignaturesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/SignaturesTest.kt
@@ -1,0 +1,125 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.common.collect.Range
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import java.security.cert.X509Certificate
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.asBufferedFlow
+import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE as SERVER_CERT_PEM_FILE
+import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_KEY_FILE as SERVER_KEY_FILE
+import org.wfanet.measurement.common.crypto.testing.KEY_ALGORITHM
+import org.wfanet.measurement.common.flatten
+
+private val DATA = ByteString.copyFromUtf8("I am some data to sign")
+private val LONG_DATA =
+  ByteString.copyFromUtf8("I am some data to sign. I am some data to sign. I am some data to sign.")
+private val ALT_DATA = ByteString.copyFromUtf8("I am some alternative data")
+
+// TODO: Consider migrating this a separate file if needed elsewhere in the repo.
+// kotlinx.coroutines.test.runBlockingTest complains about
+// "java.lang.IllegalStateException: This job has not completed yet".
+// This is a common issue: https://github.com/Kotlin/kotlinx.coroutines/issues/1204.
+private fun runBlockingTest(block: suspend CoroutineScope.() -> Unit) {
+  runBlocking { block() }
+}
+
+@RunWith(JUnit4::class)
+class SignaturesTest {
+  @Test
+  fun `sign returns signature of correct size`() {
+    val privateKey = readPrivateKey(SERVER_KEY_FILE, KEY_ALGORITHM)
+    val certificate: X509Certificate = readCertificate(SERVER_CERT_PEM_FILE)
+
+    val signature = privateKey.sign(certificate, DATA)
+
+    // DER-encoded ECDSA signature using 256-bit key can be 70, 71, or 72 bytes.
+    assertThat(signature.size()).isIn(Range.closed(70, 72))
+  }
+
+  @Test
+  fun `signFlow returns signature of correct size`() = runBlockingTest {
+    val privateKey = readPrivateKey(SERVER_KEY_FILE, KEY_ALGORITHM)
+    val certificate: X509Certificate = readCertificate(SERVER_CERT_PEM_FILE)
+
+    val (outFlow, signature) = privateKey.signFlow(certificate, LONG_DATA.asBufferedFlow(24))
+
+    assertThat(outFlow.flatten()).isEqualTo(LONG_DATA)
+
+    // DER-encoded ECDSA signature using 256-bit key can be 70, 71, or 72 bytes.
+    assertThat(signature.await().size()).isIn(Range.closed(70, 72))
+  }
+
+  @Test
+  fun `verifySignature returns true for valid signature`() {
+    val privateKey = readPrivateKey(SERVER_KEY_FILE, KEY_ALGORITHM)
+    val certificate: X509Certificate = readCertificate(SERVER_CERT_PEM_FILE)
+    val signature = privateKey.sign(certificate, DATA)
+
+    assertTrue(certificate.verifySignature(DATA, signature))
+  }
+
+  @Test
+  fun `verifySignedFlow returns true for valid signatures`() = runBlockingTest {
+    val privateKey = readPrivateKey(SERVER_KEY_FILE, KEY_ALGORITHM)
+    val certificate: X509Certificate = readCertificate(SERVER_CERT_PEM_FILE)
+    val regularSig = privateKey.sign(certificate, LONG_DATA)
+
+    val (signFlow, deferredSig) = privateKey.signFlow(certificate, LONG_DATA.asBufferedFlow(24))
+    assertThat(signFlow.flatten()).isEqualTo(LONG_DATA)
+
+    val outFlow = certificate.verifySignedFlow(LONG_DATA.asBufferedFlow(24), regularSig)
+    val outFlow2 = certificate.verifySignedFlow(LONG_DATA.asBufferedFlow(24), deferredSig.await())
+    assertThat(outFlow.flatten()).isEqualTo(LONG_DATA)
+    assertThat(outFlow2.flatten()).isEqualTo(LONG_DATA)
+  }
+
+  @Test
+  fun `verifySignature returns false for signature from different data`() {
+    val privateKey = readPrivateKey(SERVER_KEY_FILE, KEY_ALGORITHM)
+    val certificate: X509Certificate = readCertificate(SERVER_CERT_PEM_FILE)
+    val signature = privateKey.sign(certificate, DATA)
+
+    assertFalse(certificate.verifySignature(ALT_DATA, signature))
+  }
+
+  @Test
+  fun `verifySignedFlow throws for invalid signed Flow`() = runBlockingTest {
+    val privateKey = readPrivateKey(SERVER_KEY_FILE, KEY_ALGORITHM)
+    val certificate: X509Certificate = readCertificate(SERVER_CERT_PEM_FILE)
+    val signature = privateKey.sign(certificate, DATA)
+
+    val outFlow = certificate.verifySignedFlow(LONG_DATA.asBufferedFlow(24), signature)
+    assertFailsWith(InvalidSignatureException::class) {
+      assertThat(outFlow.flatten()).isEqualTo(LONG_DATA)
+    }
+
+    val (signFlow, deferredSig) = privateKey.signFlow(certificate, DATA.asBufferedFlow(24))
+    assertThat(signFlow.flatten()).isEqualTo(DATA)
+
+    val outFlow2 = certificate.verifySignedFlow(LONG_DATA.asBufferedFlow(24), deferredSig.await())
+    assertFailsWith(InvalidSignatureException::class) { outFlow2.collect() }
+  }
+}


### PR DESCRIPTION
X509Certificate.verifySignature(signedData: SignedData) will
remain in consent-signaling-client as it is only used internally
in that repo and uses a repo-specific proto.

Tests migrated as well.

Followup PR to move the references.

Note that the extensions to StorageClient and
StorageClient.Blob are kept in a separate location to avoid
depending on the signing code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/34)
<!-- Reviewable:end -->
