### PR TITLE
Make Store write/get methods open for AeadStore

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/storage/Store.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/Store.kt
@@ -47,7 +47,7 @@ protected constructor(
    * @param content [Flow] producing the content to write
    * @return [Blob] with a key derived from [context]
    */
-  suspend fun write(context: T, content: Flow<ByteString>): Blob {
+  open suspend fun write(context: T, content: Flow<ByteString>): Blob {
     val blobKey = generateBlobKey(context)
     val privateBlobKey = blobKeyPrefix + blobKey
     val createdBlob = storageClient.createBlob(privateBlobKey, content)
@@ -55,11 +55,11 @@ protected constructor(
   }
 
   /** @see write */
-  suspend fun write(context: T, content: ByteString): Blob =
+  open suspend fun write(context: T, content: ByteString): Blob =
     write(context, content.asBufferedFlow(storageClient.defaultBufferSizeBytes))
 
   /** Returns a [Blob] with the specified blob key, or `null` if not found. */
-  fun get(blobKey: String): Blob? {
+  open fun get(blobKey: String): Blob? {
     val privateBlobKey = blobKeyPrefix + blobKey
     return storageClient.getBlob(privateBlobKey)?.let { Blob(blobKey, it) }
   }

--- a/src/main/kotlin/org/wfanet/measurement/storage/Store.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/Store.kt
@@ -54,8 +54,12 @@ protected constructor(
     return Blob(blobKey, createdBlob)
   }
 
-  /** @see write */
-  open suspend fun write(context: T, content: ByteString): Blob =
+  /**
+   * Explicitly calls [write]
+   *
+   * @see write
+   */
+  suspend fun write(context: T, content: ByteString): Blob =
     write(context, content.asBufferedFlow(storageClient.defaultBufferSizeBytes))
 
   /** Returns a [Blob] with the specified blob key, or `null` if not found. */


### PR DESCRIPTION
- Inorder to implement AeadStore, the write and get methods need to be overridden so that the blob content can be encrypted before write and decrypted before returning from super

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/44)
<!-- Reviewable:end -->
