### PR TITLE
Add SigningKeyStore for storing signing private keys.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -30,8 +30,29 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "signing_key_storage",
+    srcs = [
+        "SigningKeyHandle.kt",
+        "SigningKeyStore.kt",
+    ],
+    associates = [":security_provider"],
+    deps = [
+        ":signatures",
+        ":signed_blob",
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/storage:client",
+        "//src/main/kotlin/org/wfanet/measurement/storage:store",
+    ],
+)
+
+kt_jvm_library(
     name = "security_provider",
-    srcs = ["SecurityProvider.kt"],
+    srcs = [
+        "PemIo.kt",
+        "SecurityProvider.kt",
+    ],
     deps = [
         "//imports/java/com/google/protobuf",
         "//imports/java/org/conscrypt",
@@ -46,6 +67,17 @@ kt_jvm_library(
         "//imports/java/com/google/protobuf",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:invalid_signature_exception",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
+    ],
+)
+
+kt_jvm_library(
+    name = "signed_blob",
+    srcs = ["SignedBlob.kt"],
+    deps = [
+        ":signatures",
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/storage:client",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/PemIo.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/PemIo.kt
@@ -1,0 +1,138 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+import kotlin.jvm.Throws
+import org.wfanet.measurement.common.base64Decode
+
+private const val LINE_FEED: Byte = 0x0A
+private const val LINE_FEED_INT: Int = LINE_FEED.toInt()
+private const val BEGIN_PREFIX = "-----BEGIN "
+private const val END_PREFIX = "-----END "
+private const val SUFFIX = "-----"
+private const val LINE_LENGTH = 64
+private val CHARSET = StandardCharsets.US_ASCII
+private val base64Encoder = Base64.getMimeEncoder(LINE_LENGTH, byteArrayOf(LINE_FEED))
+
+private enum class PemType(private val header: String) {
+  CERTIFICATE("CERTIFICATE"),
+  PRIVATE_KEY("PRIVATE KEY");
+
+  val begin = BEGIN_PREFIX + header + SUFFIX
+  val end = END_PREFIX + header + SUFFIX
+}
+
+/**
+ * Writer for outputting objects in PEM format.
+ *
+ * See [RFC 7468](https://datatracker.ietf.org/doc/html/rfc7468)
+ */
+internal class PemWriter(private val output: OutputStream) : AutoCloseable {
+  @Throws(IOException::class)
+  private fun write(type: PemType, der: ByteArray) {
+    with(output) {
+      write(type.begin.toByteArray(CHARSET))
+      write(LINE_FEED_INT)
+      write(base64Encoder.encode(der))
+      write(LINE_FEED_INT)
+      write(type.end.toByteArray(CHARSET))
+      write(LINE_FEED_INT)
+    }
+  }
+
+  @Throws(IOException::class)
+  fun write(certificate: X509Certificate) {
+    write(PemType.CERTIFICATE, certificate.encoded)
+  }
+
+  @Throws(IOException::class)
+  fun write(privateKey: PrivateKey) {
+    write(PemType.PRIVATE_KEY, privateKey.encoded)
+  }
+
+  @Throws(IOException::class)
+  override fun close() {
+    output.close()
+  }
+}
+
+/**
+ * Reader for inputting objects in PEM format.
+ *
+ * See [RFC 7468](https://datatracker.ietf.org/doc/html/rfc7468)
+ */
+internal class PemReader private constructor(private val reader: BufferedReader) : AutoCloseable {
+  constructor(input: InputStream) : this(input.bufferedReader(CHARSET))
+
+  constructor(inputReader: InputStreamReader) : this(inputReader.buffered()) {
+    require(inputReader.encoding == CHARSET.name())
+  }
+
+  fun readCertificate(): X509Certificate {
+    val der = checkNotNull(read(PemType.CERTIFICATE))
+    return ByteArrayInputStream(der).use { readCertificate(it) }
+  }
+
+  fun readPrivateKeySpec(): PKCS8EncodedKeySpec {
+    val der = checkNotNull(read(PemType.PRIVATE_KEY))
+    return PKCS8EncodedKeySpec(der)
+  }
+
+  private fun read(type: PemType): ByteArray? {
+    val header = readHeader() ?: return null
+    check(header == type.begin) { "Expected \"${type.begin}\", got \"$header\"" }
+
+    val buffer = StringBuffer()
+    while (true) {
+      val line = reader.readLine() ?: error("Unexpected end of file")
+      if (line.startsWith(END_PREFIX)) {
+        return buffer.toString().base64Decode()
+      }
+      buffer.append(line)
+    }
+  }
+
+  private fun readHeader(): String? {
+    var line: String
+    do {
+      line = reader.readLine() ?: return null
+    } while (line.isBlank())
+    return line
+  }
+
+  override fun close() {
+    reader.close()
+  }
+}
+
+/** Reads a private key from a PKCS#8-encoded PEM file. */
+@Throws(IOException::class)
+fun readPrivateKey(pemFile: File, algorithm: String): PrivateKey {
+  return PemReader(pemFile.inputStream()).use { reader ->
+    reader.readPrivateKeySpec().toPrivateKey(algorithm)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SignedBlob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SignedBlob.kt
@@ -1,0 +1,65 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.protobuf.ByteString
+import java.security.Signature
+import java.security.cert.X509Certificate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+import org.wfanet.measurement.common.toByteString
+import org.wfanet.measurement.storage.StorageClient
+
+class SignedBlob(wrapped: StorageClient.Blob, val signature: ByteString) :
+  StorageClient.Blob by wrapped {
+
+  /**
+   * Reads the blob content as a flow, collecting it with [action] and verifying it against
+   * [signature] using the specified [certificate].
+   *
+   * @return whether [signature] is valid for the blob content
+   */
+  suspend inline fun readAndVerify(
+    certificate: X509Certificate,
+    bufferSizeBytes: Int = storageClient.defaultBufferSizeBytes,
+    crossinline action: suspend (ByteString) -> Unit
+  ): Boolean {
+    return read(bufferSizeBytes).collectAndVerify(certificate, signature, action)
+  }
+
+  /**
+   * Returns a [Flow] for the blob content which throws an [InvalidSignatureException] on collection
+   * if [signature] is not valid for the blob content.
+   */
+  fun readVerifying(
+    certificate: X509Certificate,
+    bufferSizeBytes: Int = storageClient.defaultBufferSizeBytes
+  ): Flow<ByteString> {
+    return read(bufferSizeBytes).verifying(certificate, signature)
+  }
+}
+
+suspend fun StorageClient.createSignedBlob(
+  blobKey: String,
+  content: Flow<ByteString>,
+  newSigner: () -> Signature
+): SignedBlob {
+  val signer = newSigner()
+  val outFlow = content.onEach(signer::update)
+  val blob = createBlob(blobKey, outFlow)
+  val signature = signer.sign().toByteString()
+
+  return SignedBlob(blob, signature)
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyHandle.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyHandle.kt
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.protobuf.ByteString
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.cert.X509Certificate
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.storage.StorageClient
+
+/** Handle to the private key of a signing key pair. */
+data class SigningKeyHandle(val certificate: X509Certificate, private val privateKey: PrivateKey) {
+  fun sign(data: ByteString): ByteString = privateKey.sign(certificate, data)
+
+  fun newSigner(): Signature = privateKey.newSigner(certificate)
+
+  suspend fun write(keyStore: SigningKeyStore): String {
+    return keyStore.write(certificate, privateKey)
+  }
+}
+
+/**
+ * Terminal flow operator that collects the given flow with the provided [action] and digitally
+ * signs the accumulated values.
+ *
+ * @param keyHandle handle of signing private key
+ * @return the digital signature of the accumulated values
+ */
+suspend inline fun Flow<ByteString>.collectAndSign(
+  keyHandle: SigningKeyHandle,
+  crossinline action: suspend (ByteString) -> Unit
+): ByteString = collectAndSign(keyHandle::newSigner, action)
+
+suspend fun StorageClient.createSignedBlob(
+  blobKey: String,
+  content: Flow<ByteString>,
+  signingKey: SigningKeyHandle
+): SignedBlob = createSignedBlob(blobKey, content, signingKey::newSigner)

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStore.kt
@@ -1,0 +1,64 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.protobuf.ByteString
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wfanet.measurement.common.HexString
+import org.wfanet.measurement.common.flatten
+import org.wfanet.measurement.storage.Store
+import org.wfanet.measurement.storage.read
+
+/** Store of private signing keys. */
+class SigningKeyStore(private val store: Store<Context>) {
+  data class Context(val subjectKeyIdentifier: ByteString) {
+    fun generateBlobKey(): String {
+      return "/${HexString(subjectKeyIdentifier).value}/${UUID.randomUUID()}"
+    }
+
+    companion object {
+      fun fromCertificate(certificate: X509Certificate): Context {
+        return Context(requireNotNull(certificate.subjectKeyIdentifier))
+      }
+    }
+  }
+
+  internal suspend fun write(certificate: X509Certificate, privateKey: PrivateKey): String {
+    val pemBytes =
+      ByteString.newOutput().use { output ->
+        val writer = PemWriter(output)
+        withContext(Dispatchers.IO) {
+          writer.write(certificate)
+          writer.write(privateKey)
+        }
+        output.toByteString()
+      }
+    val blob = store.write(Context.fromCertificate(certificate), pemBytes)
+    return blob.blobKey
+  }
+
+  suspend fun read(keyId: String): SigningKeyHandle? {
+    val blob = store.get(keyId) ?: return null
+    return PemReader(blob.read().flatten().newInput()).use { reader ->
+      val certificate = reader.readCertificate()
+      val privateKey = reader.readPrivateKeySpec().toPrivateKey(certificate.publicKey.algorithm)
+      SigningKeyHandle(certificate, privateKey)
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/testing/BUILD.bazel
@@ -12,6 +12,9 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common/crypto/testing/testdata:static_certs",
     ],
     deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/protobuf",
         "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/testing/SignatureSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/testing/SignatureSubject.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.crypto.testing
+
+import com.google.common.truth.Fact
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Subject
+import com.google.common.truth.Truth
+import com.google.protobuf.ByteString
+import java.security.cert.X509Certificate
+import org.wfanet.measurement.common.crypto.subjectKeyIdentifier
+import org.wfanet.measurement.common.crypto.verifySignature
+
+class SignatureSubject private constructor(failureMetadata: FailureMetadata, subject: ByteString) :
+  Subject(failureMetadata, subject) {
+
+  private val actual = subject
+
+  fun isValidFor(certificate: X509Certificate, data: ByteString) {
+    if (!certificate.verifySignature(data, actual)) {
+      failWithActual(
+        Fact.simpleFact("cannot be verified"),
+        Fact.fact("certificate SKID", certificate.subjectKeyIdentifier),
+        Fact.fact("data", data)
+      )
+    }
+  }
+
+  companion object {
+    fun assertThat(actual: ByteString): SignatureSubject =
+      Truth.assertAbout(signatures()).that(actual)
+
+    fun signatures(): (failureMetadata: FailureMetadata, subject: ByteString) -> SignatureSubject =
+      ::SignatureSubject
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -29,8 +29,8 @@ kt_jvm_library(
     name = "verified_storage_extensions",
     srcs = ["VerifiedStorageExtensions.kt"],
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/common/crypto:invalid_signature_exception",
+        ":client",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
-        "//src/main/kotlin/org/wfanet/measurement/storage:client",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:signed_blob",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -44,3 +44,22 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "SigningKeyStoreTest",
+    srcs = ["SigningKeyStoreTest.kt"],
+    test_class = "org.wfanet.measurement.common.crypto.SigningKeyStoreTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/protobuf",
+        "//imports/java/org/junit",
+        "//imports/kotlin/kotlin/test",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_key_storage",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
+        "//src/main/kotlin/org/wfanet/measurement/storage:store",
+        "//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
+        "//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStoreTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStoreTest.kt
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.common.truth.Truth.assertThat
+import java.security.cert.X509Certificate
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE
+import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_KEY_FILE
+import org.wfanet.measurement.common.flatten
+import org.wfanet.measurement.storage.Store
+import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
+import org.wfanet.measurement.storage.read
+
+@RunWith(JUnit4::class)
+class SigningKeyStoreTest {
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private lateinit var store: Store<SigningKeyStore.Context>
+  private lateinit var signingKeyStore: SigningKeyStore
+
+  @Before
+  fun initSigningKeyStore() {
+    val storageClient = FileSystemStorageClient(tempDir.root)
+    store =
+      object :
+        Store<SigningKeyStore.Context>(storageClient, SigningKeyStore.Context::generateBlobKey) {
+        override val blobKeyPrefix: String = "/sigKeys"
+      }
+    signingKeyStore = SigningKeyStore(store)
+  }
+
+  @Test
+  fun `write writes PEM file to store`() = runBlocking {
+    val keyId: String = SigningKeyHandle(certificate, privateKey).write(signingKeyStore)
+
+    val blob = assertNotNull(store.get(keyId))
+    assertThat(blob.read().flatten().toStringUtf8()).isEqualTo(CONCATENATED_PEM)
+  }
+
+  @Test
+  fun `read reads signing key from store`() = runBlocking {
+    val privateKey = SigningKeyHandle(certificate, privateKey)
+    val keyId: String = privateKey.write(signingKeyStore)
+
+    val readKey: SigningKeyHandle = assertNotNull(signingKeyStore.read(keyId))
+
+    assertThat(readKey).isEqualTo(privateKey)
+  }
+
+  companion object {
+    private val CONCATENATED_PEM: String =
+      FIXED_SERVER_CERT_PEM_FILE.readText() + FIXED_SERVER_KEY_FILE.readText()
+
+    private val certificate: X509Certificate = readCertificate(FIXED_SERVER_CERT_PEM_FILE)
+    private val privateKey = readPrivateKey(FIXED_SERVER_KEY_FILE, certificate.publicKey.algorithm)
+  }
+}


### PR DESCRIPTION
Each private key is stored with its associated certificate. This ensures that the key type and signing algorithm are stored along with the private key material.

A private key read from this class is wrapped in a SigningKeyHandle. This prevents the private key material from being exposed to anything other than signing operations.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/48)
<!-- Reviewable:end -->

https://rally1.rallydev.com/#/?detail=/task/611718944581&fdp=true