### PR TITLE
Avoid unnecessary byte array copies when computing SHA-256 hash.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -12,7 +12,11 @@ kt_jvm_library(
 kt_jvm_library(
     name = "hashing",
     srcs = ["Hashing.kt"],
-    deps = ["@wfa_common_jvm//imports/java/com/google/protobuf"],
+    deps = [
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+    ],
 )
 
 kt_jvm_library(


### PR DESCRIPTION
This also adds a hashing Flow operator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/52)
<!-- Reviewable:end -->
