### PR TITLE
change dependencies to more direct paths

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -36,11 +36,12 @@ kt_jvm_library(
 kt_jvm_library(
     name = "signing_key_storage",
     srcs = [
+        "PemIo.kt",
         "SigningKeyHandle.kt",
         "SigningKeyStore.kt",
     ],
-    associates = [":security_provider"],
     deps = [
+        ":security_provider",
         ":signatures",
         ":signed_blob",
         "//imports/java/com/google/protobuf",
@@ -55,7 +56,6 @@ kt_jvm_library(
 kt_jvm_library(
     name = "security_provider",
     srcs = [
-        "PemIo.kt",
         "SecurityProvider.kt",
     ],
     deps = [
@@ -70,6 +70,8 @@ kt_jvm_library(
     srcs = ["Signatures.kt"],
     deps = [
         "//imports/java/com/google/protobuf",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:invalid_signature_exception",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
     ],
@@ -82,6 +84,7 @@ kt_jvm_library(
         ":signatures",
         "//imports/java/com/google/protobuf",
         "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/kotlin/org/wfanet/measurement/storage:client",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -30,6 +30,8 @@ kt_jvm_library(
     srcs = ["VerifiedStorageExtensions.kt"],
     deps = [
         ":client",
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:signed_blob",
     ],


### PR DESCRIPTION
- add dependencies to protobuf and kotlinx where needed, rather than
relying on indirect imports
- move PemIo into signing storage as it has internal methods only used
there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/63)
<!-- Reviewable:end -->
