### PR TITLE
Fix KmsStorageClient.createBlob returning encrypted wrapped blob.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/BUILD.bazel
@@ -10,6 +10,7 @@ kt_jvm_library(
         "//imports/java/software/amazon/awssdk/core",
         "//imports/java/software/amazon/awssdk/http",
         "//imports/java/software/amazon/awssdk/services/s3",
+        "//imports/kotlin/com/google/protobuf/kotlin",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/storage:client",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -15,6 +15,7 @@
 package org.wfanet.measurement.aws.s3
 
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import java.security.MessageDigest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -24,7 +25,6 @@ import org.wfanet.measurement.common.BYTES_PER_MIB
 import org.wfanet.measurement.common.HexString
 import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.measurement.common.asFlow
-import org.wfanet.measurement.common.toByteString
 import org.wfanet.measurement.storage.StorageClient
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
@@ -31,7 +31,8 @@ import org.wfanet.measurement.storage.read
  * @param storageClient underlying client for accessing blob/object storage
  * @param aead Tink AEAD integration specific encrypt/decrypt
  */
-internal class KmsStorageClient(private val storageClient: StorageClient, private val aead: Aead) :
+class KmsStorageClient
+internal constructor(private val storageClient: StorageClient, private val aead: Aead) :
   StorageClient {
 
   override val defaultBufferSizeBytes: Int
@@ -40,15 +41,18 @@ internal class KmsStorageClient(private val storageClient: StorageClient, privat
   /**
    * Creates a blob with the specified [blobKey] and [content] encrypted by [aead].
    *
+   * @param blobKey the key for the blob. This is used as the AEAD associated data.
    * @param content [Flow] producing the content be encrypted and stored in the blob
    * @return [StorageClient.Blob] with [content] encrypted by [aead]
    */
   override suspend fun createBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
-    val ciphertext = aead.encrypt(content.toByteArray(), null)
-    return storageClient.createBlob(
-      blobKey,
-      ciphertext.asBufferedFlow(storageClient.defaultBufferSizeBytes)
-    )
+    val ciphertext = aead.encrypt(content.toByteArray(), blobKey.encodeToByteArray())
+    val wrappedBlob =
+      storageClient.createBlob(
+        blobKey,
+        ciphertext.asBufferedFlow(storageClient.defaultBufferSizeBytes)
+      )
+    return AeadBlob(wrappedBlob, blobKey)
   }
 
   /**
@@ -58,11 +62,12 @@ internal class KmsStorageClient(private val storageClient: StorageClient, privat
    */
   override fun getBlob(blobKey: String): StorageClient.Blob? {
     val blob = storageClient.getBlob(blobKey)
-    return blob?.let { AeadBlob(blob) }
+    return blob?.let { AeadBlob(it, blobKey) }
   }
 
   /** A blob that will decrypt the content when read */
-  private inner class AeadBlob(private val blob: StorageClient.Blob) : StorageClient.Blob {
+  private inner class AeadBlob(private val blob: StorageClient.Blob, private val blobKey: String) :
+    StorageClient.Blob {
     override val storageClient = this@KmsStorageClient.storageClient
 
     override val size: Long
@@ -70,7 +75,11 @@ internal class KmsStorageClient(private val storageClient: StorageClient, privat
 
     override fun read(bufferSizeBytes: Int) =
       flow {
-          emit(this@KmsStorageClient.aead.decrypt(blob.read().toByteArray(), null).toByteString())
+          emit(
+            this@KmsStorageClient.aead
+              .decrypt(blob.read().toByteArray(), blobKey.encodeToByteArray())
+              .toByteString()
+          )
         }
         .asBufferedFlow(bufferSizeBytes)
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing/BUILD.bazel
@@ -12,6 +12,7 @@ kt_jvm_library(
     deps = [
         "@tink_java//src/main/java/com/google/crypto/tink:binary_keyset_reader",
         "@tink_java//src/main/java/com/google/crypto/tink:cleartext_keyset_handle",
+        "@tink_java//src/main/java/com/google/crypto/tink:kms_client",
         "@tink_java//src/main/java/com/google/crypto/tink:registry_cluster",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing/FakeKmsClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing/FakeKmsClient.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.crypto.tink.testing
+
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KmsClient
+import java.security.GeneralSecurityException
+
+class FakeKmsClient : KmsClient {
+  private val keyAeads = mutableMapOf<String, Aead>()
+
+  override fun doesSupport(keyUri: String?): Boolean {
+    return keyUri?.startsWith(KEY_URI_PREFIX) ?: false
+  }
+
+  override fun withCredentials(credentialPath: String?): KmsClient {
+    if (credentialPath == null) {
+      return withDefaultCredentials()
+    }
+    throw UnsupportedOperationException("Not implemented")
+  }
+
+  override fun withDefaultCredentials(): KmsClient {
+    return this
+  }
+
+  override fun getAead(keyUri: String?): Aead {
+    if (!doesSupport(keyUri)) {
+      throw GeneralSecurityException("URI not supported")
+    }
+    return keyAeads[keyUri] ?: throw GeneralSecurityException("Invalid key URI")
+  }
+
+  fun addAead(keyUri: String, aead: Aead) {
+    require(doesSupport(keyUri)) { "URI not supported" }
+    keyAeads[keyUri] = aead
+  }
+
+  companion object {
+    const val KEY_URI_PREFIX = "fake-kms://"
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -29,6 +29,13 @@ import org.wfanet.measurement.storage.testing.BlobSubject.Companion.assertThat
 
 /** Abstract base class for testing implementations of [StorageClient]. */
 abstract class AbstractStorageClientTest<T : StorageClient> {
+  protected val testBlobContent: ByteString
+    get() = Companion.testBlobContent
+
+  open fun computeStoredBlobSize(content: ByteString, blobKey: String): Int {
+    return content.size
+  }
+
   protected lateinit var storageClient: T
 
   @Test
@@ -53,17 +60,16 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
     val blob = assertNotNull(storageClient.getBlob(blobKey))
 
-    assertThat(blob).hasSize(testBlobContent.size)
     assertThat(blob).contentEqualTo(testBlobContent)
   }
 
   @Test
   fun `Blob size returns content size`() = runBlocking {
-    val blobKey = "blob-to-check-size"
+    val blobKey = "blob-to-check-size-" + random.nextInt().toString()
 
     val blob = storageClient.createBlob(blobKey, testBlobContent)
 
-    assertThat(blob).hasSize(testBlobContent.size)
+    assertThat(blob).hasSize(computeStoredBlobSize(testBlobContent, blobKey))
   }
 
   @Test

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/BUILD.bazel
@@ -12,6 +12,7 @@ kt_jvm_library(
         "//imports/java/com/google/common/truth",
         "//imports/java/com/google/protobuf",
         "//imports/java/org/junit",
+        "//imports/kotlin/com/google/protobuf/kotlin",
         "//imports/kotlin/kotlin/test",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common",

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/BUILD.bazel
@@ -11,3 +11,16 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "KmsStorageClientTest",
+    srcs = ["KmsStorageClientTest.kt"],
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/org/junit",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto/tink",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing",
+        "//src/main/kotlin/org/wfanet/measurement/storage/testing",
+        "@tink_java//src/main/java/com/google/crypto/tink/aead:aead_config",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClientTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.crypto.tink
+
+import com.google.common.truth.Truth.assertThat
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.KmsClients
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
+import org.wfanet.measurement.common.size
+import org.wfanet.measurement.common.toByteArray
+import org.wfanet.measurement.storage.createBlob
+import org.wfanet.measurement.storage.read
+import org.wfanet.measurement.storage.testing.AbstractStorageClientTest
+import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+
+@RunWith(JUnit4::class)
+class KmsStorageClientTest : AbstractStorageClientTest<KmsStorageClient>() {
+  private val wrappedStorageClient = InMemoryStorageClient()
+
+  override fun computeStoredBlobSize(content: ByteString, blobKey: String): Int {
+    // See https://github.com/google/tink/blob/master/docs/WIRE-FORMAT.md
+    // AES_128_GCM ciphertext is same size as plaintext.
+    return TINK_PREFIX_SIZE_BYTES + AEAD_IV_SIZE_BYTES + content.size + AEAD_TAG_SIZE_BYTES
+  }
+
+  @Before
+  fun initStorageClient() {
+    storageClient =
+      TinkKeyStorageProvider().makeKmsStorageClient(wrappedStorageClient, KEK_URI) as
+        KmsStorageClient
+  }
+
+  @Test
+  fun `wrapped blob is encrypted`() = runBlocking {
+    val blobKey = "kms-blob"
+
+    storageClient.createBlob(blobKey, testBlobContent)
+
+    val wrappedBlob = assertNotNull(wrappedStorageClient.getBlob(blobKey))
+    val plainTextContent =
+      aead.decrypt(wrappedBlob.read().toByteArray(), blobKey.encodeToByteArray()).toByteString()
+    assertThat(plainTextContent).isEqualTo(testBlobContent)
+  }
+
+  companion object {
+    private const val TINK_PREFIX_SIZE_BYTES = 5
+    private const val AEAD_IV_SIZE_BYTES = 12
+    private const val AEAD_TAG_SIZE_BYTES = 16
+
+    private const val KEK_URI = FakeKmsClient.KEY_URI_PREFIX + "kek"
+
+    init {
+      AeadConfig.register()
+    }
+    private val AEAD_KEY_TEMPLATE = KeyTemplates.get("AES128_GCM")
+    private val KEY_ENCRYPTION_KEY = KeysetHandle.generateNew(AEAD_KEY_TEMPLATE)
+    private val aead = KEY_ENCRYPTION_KEY.getPrimitive(Aead::class.java)
+
+    init {
+      KmsClients.add(FakeKmsClient().apply { addAead(KEK_URI, aead) })
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/storage/testing/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/testing/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "InMemoryStorageClientTest",
+    srcs = ["InMemoryStorageClientTest.kt"],
+    test_class = "org.wfanet.measurement.storage.testing.InMemoryStorageClientTest",
+    deps = [
+        "//imports/java/org/junit",
+        "//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.storage.testing
+
+import org.junit.Before
+
+class InMemoryStorageClientTest : AbstractStorageClientTest<InMemoryStorageClient>() {
+  @Before
+  fun initStorageClient() {
+    storageClient = InMemoryStorageClient()
+  }
+}


### PR DESCRIPTION
This also adds tests for `KmsStorageClient` and `InMemoryStorageClient`, and uses the blob key as the associated data for KMS AEAD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/73)
<!-- Reviewable:end -->
