### PR TITLE
Add base64 encoding conversions for ByteString and Long.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Base64.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Base64.kt
@@ -14,14 +14,34 @@
 
 package org.wfanet.measurement.common
 
+import com.google.protobuf.ByteString
+import java.nio.ByteBuffer
 import java.util.Base64
 
+private val urlEncoder = Base64.getUrlEncoder().withoutPadding()
+private val urlDecoder = Base64.getUrlDecoder()
+
+/** Encodes this [ByteString] into an RFC 7515 base64url-encoded [String]. */
+fun ByteString.base64UrlEncode(): String = encode(urlEncoder)
+
+/** Decodes this RFC 7515 base64url-encoded [String] into a [ByteString]. */
+fun String.base64UrlDecode(): ByteString = decode(urlDecoder)
+
 /** Encodes [ByteArray] with RFC 7515's Base64url encoding into a base-64 string. */
-fun ByteArray.base64UrlEncode(): String =
-  Base64.getUrlEncoder().withoutPadding().encodeToString(this)
+fun ByteArray.base64UrlEncode(): String = urlEncoder.encodeToString(this)
 
-/** Decodes a [String] encoded with RFC 7515's Base64url into a [ByteArray]. */
-fun String.base64UrlDecode(): ByteArray = Base64.getUrlDecoder().decode(this)
+fun Long.base64UrlEncode(): String {
+  return toReadOnlyByteBuffer().encode(urlEncoder)
+}
 
-/** Decodes this base64-encoded [String] to a [ByteArray]. */
-fun String.base64Decode(): ByteArray = Base64.getDecoder().decode(this)
+private fun ByteString.encode(encoder: Base64.Encoder): String {
+  return asReadOnlyByteBuffer().encode(encoder)
+}
+
+private fun ByteBuffer.encode(encoder: Base64.Encoder): String {
+  return String(encoder.encode(this).array(), Charsets.ISO_8859_1)
+}
+
+private fun String.decode(decoder: Base64.Decoder): ByteString {
+  return ByteString.readFrom(decoder.wrap(byteInputStream(Charsets.ISO_8859_1)))
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
@@ -19,6 +19,7 @@ import com.google.protobuf.kotlin.toByteString
 import java.io.File
 import java.io.InputStream
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.nio.channels.ReadableByteChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
@@ -66,6 +67,21 @@ fun Iterable<ByteString>.toByteArray(): ByteArray {
 /** @see ByteString.size(). */
 val ByteString.size: Int
   get() = size()
+
+fun ByteString.toLong(): Long {
+  require(size == 8) { "Expected 8 bytes, got $size" }
+  return asReadOnlyByteBuffer().long
+}
+
+fun Long.toByteString(): ByteString {
+  return ByteString.copyFrom(toReadOnlyByteBuffer())
+}
+
+fun Long.toReadOnlyByteBuffer(): ByteBuffer {
+  val buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(this)
+  buffer.flip()
+  return buffer.asReadOnlyBuffer()
+}
 
 /**
  * Returns a [ByteString] with the same contents, padded with zeros in its most-significant bits

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/PemIo.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/PemIo.kt
@@ -27,7 +27,6 @@ import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import java.util.Base64
 import kotlin.jvm.Throws
-import org.wfanet.measurement.common.base64Decode
 
 private const val LINE_FEED: Byte = 0x0A
 private const val LINE_FEED_INT: Int = LINE_FEED.toInt()
@@ -136,3 +135,6 @@ fun readPrivateKey(pemFile: File, algorithm: String): PrivateKey {
     reader.readPrivateKeySpec().toPrivateKey(algorithm)
   }
 }
+
+/** Decodes this base64-encoded [String] to a [ByteArray]. */
+private fun String.base64Decode(): ByteArray = Base64.getDecoder().decode(this)

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/Identifiers.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/Identifiers.kt
@@ -14,9 +14,9 @@
 
 package org.wfanet.measurement.common.identity
 
-import java.math.BigInteger
 import org.wfanet.measurement.common.base64UrlDecode
 import org.wfanet.measurement.common.base64UrlEncode
+import org.wfanet.measurement.common.toLong
 
 /**
  * Typesafe wrapper around Long to represent the integer format used below the service layer for the
@@ -29,7 +29,7 @@ data class ExternalId(val value: Long) {
     require(value > 0) { "Negative id numbers and 0 are not permitted: $value" }
   }
 
-  val apiId: ApiId by lazy { ApiId(value.toByteArray().base64UrlEncode()) }
+  val apiId: ApiId by lazy { ApiId(value.base64UrlEncode()) }
 
   override fun toString(): String = "ExternalId($value / ${apiId.value})"
 }
@@ -55,17 +55,5 @@ fun externalIdToApiId(id: Long): String = ExternalId(id).apiId.value
 data class InternalId(val value: Long) {
   init {
     require(value != 0L) { "0 is not permitted" }
-  }
-}
-
-// An alternative is: toBigInteger().toByteArray(), but that includes the sign bit, which uses an
-// extra byte.
-private fun Long.toByteArray(): ByteArray =
-  ByteArray(8) { ((this shr ((7 - it) * 8)) and 0xFF).toByte() }
-
-private fun ByteArray.toLong(): Long {
-  require(size == 8) { "Invalid conversion: $this is not 8 bytes" }
-  return BigInteger(this).toLong().also {
-    require(it >= 0L) { "Negative id numbers are not permitted: $it" }
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -16,6 +16,18 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "Base64Test",
+    srcs = ["Base64Test.kt"],
+    test_class = "org.wfanet.measurement.common.Base64Test",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/protobuf",
+        "//imports/java/org/junit",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)
+
+kt_jvm_test(
     name = "ProtoUtilsTest",
     srcs = ["ProtoUtilsTest.kt"],
     test_class = "org.wfanet.measurement.common.ProtoUtilsTest",

--- a/src/test/kotlin/org/wfanet/measurement/common/Base64Test.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/Base64Test.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.kotlin.toByteStringUtf8
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class Base64Test {
+  @Test
+  fun `ByteString base64UrlEncode returns encoded string without padding`() {
+    assertThat(BYTE_STRING_VALUE.base64UrlEncode()).isEqualTo(STRING_VALUE_BASE64_URL)
+  }
+
+  @Test
+  fun `ByteArray base64UrlEncode returns encoded string without padding`() {
+    assertThat(BYTE_ARRAY_VALUE.base64UrlEncode()).isEqualTo(STRING_VALUE_BASE64_URL)
+  }
+
+  @Test
+  fun `String base64UrlDecode returns ByteString value`() {
+    assertThat(STRING_VALUE_BASE64_URL.base64UrlDecode()).isEqualTo(BYTE_STRING_VALUE)
+  }
+
+  @Test
+  fun `Long base64UrlEncode round-trips`() {
+    assertThat(LONG_VALUE.base64UrlEncode().base64UrlDecode().toLong()).isEqualTo(LONG_VALUE)
+  }
+
+  companion object {
+    private const val STRING_VALUE = "a string"
+    private const val STRING_VALUE_BASE64_URL = "YSBzdHJpbmc"
+    private val BYTE_STRING_VALUE = STRING_VALUE.toByteStringUtf8()
+    private val BYTE_ARRAY_VALUE = STRING_VALUE.encodeToByteArray()
+
+    private const val LONG_VALUE = -5260288547287550606L // Hex: B6FFB36FBADEB572
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/common/BytesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/BytesTest.kt
@@ -29,6 +29,15 @@ import org.junit.runners.JUnit4
 @OptIn(ExperimentalCoroutinesApi::class) // For `runBlockingTest`.
 class BytesTest {
   @Test
+  fun `ByteString is bidirectionally convertible with Long`() {
+    val longValue = -3519155157501101422L
+    val binaryValue = HexString("CF2973078FA9BA92").bytes
+
+    assertThat(longValue.toByteString()).isEqualTo(binaryValue)
+    assertThat(binaryValue.toLong()).isEqualTo(longValue)
+  }
+
+  @Test
   fun `ByteString asBufferedFlow with non-full last part`() = runBlockingTest {
     val flow = ByteString.copyFromUtf8("Hello World").asBufferedFlow(3)
     assertThat(flow.map { it.toStringUtf8() }.toList())

--- a/src/test/kotlin/org/wfanet/measurement/common/identity/IdentifiersTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/identity/IdentifiersTest.kt
@@ -15,6 +15,7 @@
 package org.wfanet.measurement.common.identity
 
 import com.google.common.truth.Truth.assertThat
+import java.io.IOException
 import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,8 +55,8 @@ class IdentifiersTest {
 
   @Test
   fun `invalid base64 string`() {
-    assertFailsWith<IllegalArgumentException> { ApiId("12345678!") }
-    assertFailsWith<IllegalArgumentException> { ApiId("012345678") }
+    assertFailsWith<IOException> { ApiId("12345678!") }
+    assertFailsWith<IOException> { ApiId("012345678") }
   }
 
   @Test


### PR DESCRIPTION
This technically makes a "breaking" change by swapping the return type of String.base64UrlEncode, but all known calls should be unaffected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/74)
<!-- Reviewable:end -->
