### PR TITLE
Mark org.wfanet.measurement.common.toByteString as deprecated.

### DIFF
--- a/imports/kotlin/com/google/protobuf/kotlin/BUILD.bazel
+++ b/imports/kotlin/com/google/protobuf/kotlin/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "kotlin",
+    actual = "@maven//:com_google_protobuf_protobuf_kotlin",
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -15,6 +15,7 @@ kt_jvm_library(
         "//imports/java/com/google/protobuf",
         "//imports/java/com/google/protobuf/util",
         "//imports/java/picocli",
+        "//imports/kotlin/com/google/protobuf/kotlin",
         "//imports/kotlin/kotlinx/coroutines:core",
         "@com_google_googleapis//google/type:type_java_proto",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
@@ -15,6 +15,7 @@
 package org.wfanet.measurement.common
 
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.nio.channels.ReadableByteChannel
@@ -33,7 +34,11 @@ import kotlinx.coroutines.isActive
 
 const val BYTES_PER_MIB = 1024 * 1024
 
-fun ByteArray.toByteString(): ByteString = ByteString.copyFrom(this)
+@Deprecated(
+  "Use com.google.protobuf.kotlin.toByteString",
+  ReplaceWith("toByteString()", "com.google.protobuf.kotlin.toByteString")
+)
+fun ByteArray.toByteString(): ByteString = toByteString()
 
 fun Iterable<ByteArray>.toByteString(): ByteString {
   val totalSize = sumBy { it.size }

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/Hashing.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/Hashing.kt
@@ -15,12 +15,12 @@
 package org.wfanet.measurement.common.crypto
 
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.MessageDigest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
-import org.wfanet.measurement.common.toByteString
 
 private const val SHA_256 = "SHA-256"
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/Signatures.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/Signatures.kt
@@ -15,6 +15,7 @@
 package org.wfanet.measurement.common.crypto
 
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import java.security.PrivateKey
 import java.security.Signature
 import java.security.cert.X509Certificate
@@ -25,7 +26,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import org.wfanet.measurement.common.toByteString
 
 /** @see [Signature.update] */
 fun Signature.update(bytes: ByteString) {

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SignedBlob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SignedBlob.kt
@@ -15,11 +15,11 @@
 package org.wfanet.measurement.common.crypto
 
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import java.security.Signature
 import java.security.cert.X509Certificate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
-import org.wfanet.measurement.common.toByteString
 import org.wfanet.measurement.storage.StorageClient
 
 class SignedBlob(wrapped: StorageClient.Blob, val signature: ByteString) :

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KeyHandle.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KeyHandle.kt
@@ -22,9 +22,9 @@ import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.hybrid.HybridConfig
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.common.crypto.PublicKeyHandle
-import org.wfanet.measurement.common.toByteString
 
 class TinkPublicKeyHandle internal constructor(internal val keysetHandle: KeysetHandle) :
   PublicKeyHandle {

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
@@ -16,11 +16,11 @@ package org.wfanet.measurement.common.crypto.tink
 
 import com.google.crypto.tink.Aead
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.measurement.common.toByteArray
-import org.wfanet.measurement.common.toByteString
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.read
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -16,13 +16,13 @@ package org.wfanet.measurement.storage.testing
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
 import kotlin.random.Random
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.wfanet.measurement.common.BYTES_PER_MIB
 import org.wfanet.measurement.common.size
-import org.wfanet.measurement.common.toByteString
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.createBlob
 import org.wfanet.measurement.storage.testing.BlobSubject.Companion.assertThat


### PR DESCRIPTION
com.google.protobuf.kotlin.toByteString should be used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/75)
<!-- Reviewable:end -->
