### PR TITLE
Ensure Tink Hybrid encryption primitives are registered before decrypting.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KeyHandle.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KeyHandle.kt
@@ -49,6 +49,10 @@ class TinkPublicKeyHandle internal constructor(internal val keysetHandle: Keyset
   }
 
   companion object {
+    init {
+      HybridConfig.register()
+    }
+
     private fun parseKeyset(serialized: ByteString): KeysetHandle {
       return serialized.newInput().use {
         KeysetHandle.readNoSecret(BinaryKeysetReader.withInputStream(it))


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/85)
<!-- Reviewable:end -->
https://rally1.rallydev.com/#/?detail=/task/623033865659&fdp=true