### PR TITLE
Update the checksum of rules_jvm_external.

### DIFF
--- a/build/rules_jvm_external/repo.bzl
+++ b/build/rules_jvm_external/repo.bzl
@@ -22,7 +22,7 @@ def rules_jvm_external_repo():
     if "rules_jvm_external" not in native.existing_rules():
         http_archive(
             name = "rules_jvm_external",
-            sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
+            sha256 = "e34ff633e6b8ea44c4f911b15b28079b17968694e2caa57b369c754208c16e4d",
             strip_prefix = "rules_jvm_external-4.2",
             url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.2.zip",
         )


### PR DESCRIPTION
It is breaking the cross-media-measurement repo's build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/87)
<!-- Reviewable:end -->
