### PR TITLE
Include kt_jvm_proto_library in Kotlin gRPC macro.

### DIFF
--- a/build/kt_jvm_proto/defs.bzl
+++ b/build/kt_jvm_proto/defs.bzl
@@ -111,12 +111,12 @@ _kt_jvm_proto_aspect = aspect(
     attrs = {
         "_zipper": attr.label(
             default = Label("@bazel_tools//tools/zip:zipper"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "_protoc": attr.label(
             default = Label("@com_google_protobuf//:protoc"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },
@@ -141,12 +141,12 @@ _kt_jvm_proto_library_helper = rule(
         ),
         "_zipper": attr.label(
             default = Label("@bazel_tools//tools/zip:zipper"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "_extract_srcjars": attr.label(
             default = Label("@wfa_common_jvm//build/kt_jvm_proto:extract_srcjars"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
@@ -25,7 +25,7 @@ kt_jvm_library(
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/kotlin/org/wfanet/measurement/storage:client",
-        "//src/main/proto/wfa/measurement/internal/testing:forwarded_storage_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/internal/testing:forwarded_storage_service_kt_jvm_grpc_proto",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/forwarded/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/forwarded/BUILD.bazel
@@ -12,6 +12,6 @@ kt_jvm_library(
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc",
         "//src/main/kotlin/org/wfanet/measurement/storage:client",
-        "//src/main/proto/wfa/measurement/internal/testing:forwarded_storage_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/internal/testing:forwarded_storage_service_kt_jvm_grpc_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/internal/testing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/testing/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//build:macros.bzl", "kt_jvm_grpc_and_java_proto_library")
+load("//build:macros.bzl", "kt_jvm_grpc_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -9,7 +9,7 @@ proto_library(
     strip_import_prefix = "/src/main/proto",
 )
 
-kt_jvm_grpc_and_java_proto_library(
-    name = "forwarded_storage_service_kt_jvm_grpc",
+kt_jvm_grpc_proto_library(
+    name = "forwarded_storage_service_kt_jvm_grpc_proto",
     srcs = [":forwarded_storage_service_proto"],
 )

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -12,7 +12,7 @@ kt_jvm_test(
         "//imports/kotlin/kotlinx/coroutines:core",
         "//imports/kotlin/kotlinx/coroutines/test",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc",
-        "//src/test/proto/wfa/measurement/common:fake_service_kt_jvm_grpc",
+        "//src/test/proto/wfa/measurement/common:fake_service_kt_jvm_grpc_proto",
         "@io_grpc_grpc_java//core",
         "@io_grpc_grpc_java//testing",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/filesystem/BUILD.bazel
@@ -26,6 +26,6 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/storage/filesystem:service",
         "//src/main/kotlin/org/wfanet/measurement/storage/forwarded",
         "//src/main/kotlin/org/wfanet/measurement/storage/testing",
-        "//src/main/proto/wfa/measurement/internal/testing:forwarded_storage_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/internal/testing:forwarded_storage_service_kt_jvm_grpc_proto",
     ],
 )

--- a/src/test/proto/wfa/measurement/common/BUILD.bazel
+++ b/src/test/proto/wfa/measurement/common/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//build/kt_jvm_proto:defs.bzl", "kt_jvm_proto_library")
-load("//build:macros.bzl", "kt_jvm_grpc_and_java_proto_library")
+load("//build:macros.bzl", "kt_jvm_grpc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
@@ -31,7 +31,7 @@ proto_library(
     strip_import_prefix = "/src/test/proto",
 )
 
-kt_jvm_grpc_and_java_proto_library(
-    name = "fake_service_kt_jvm_grpc",
+kt_jvm_grpc_proto_library(
+    name = "fake_service_kt_jvm_grpc_proto",
     srcs = [":fake_service_proto"],
 )


### PR DESCRIPTION
This renames the macro from kt_jvm_grpc_and_java_proto_library to kt_jvm_grpc_proto_library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/89)
<!-- Reviewable:end -->
