### PR TITLE
Allow overwriting blob content.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -41,7 +41,7 @@ private const val BYTE_BUFFER_SIZE = BYTES_PER_MIB * 5
 class S3StorageClient(private val s3: S3Client, private val bucketName: String) : StorageClient {
   override val defaultBufferSizeBytes: Int = BYTE_BUFFER_SIZE
 
-  override suspend fun createBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
     val uploadId = createMultipartUpload(blobKey)
 
     try {

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SignedBlob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SignedBlob.kt
@@ -58,7 +58,7 @@ suspend fun StorageClient.createSignedBlob(
 ): SignedBlob {
   val signer = newSigner()
   val outFlow = content.onEach(signer::update)
-  val blob = createBlob(blobKey, outFlow)
+  val blob = writeBlob(blobKey, outFlow)
   val signature = signer.sign().toByteString()
 
   return SignedBlob(blob, signature)

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
@@ -45,10 +45,10 @@ internal constructor(private val storageClient: StorageClient, private val aead:
    * @param content [Flow] producing the content be encrypted and stored in the blob
    * @return [StorageClient.Blob] with [content] encrypted by [aead]
    */
-  override suspend fun createBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
     val ciphertext = aead.encrypt(content.toByteArray(), blobKey.encodeToByteArray())
     val wrappedBlob =
-      storageClient.createBlob(
+      storageClient.writeBlob(
         blobKey,
         ciphertext.asBufferedFlow(storageClient.defaultBufferSizeBytes)
       )

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -43,7 +43,7 @@ class GcsStorageClient(private val storage: Storage, private val bucketName: Str
   override val defaultBufferSizeBytes: Int
     get() = BYTE_BUFFER_SIZE
 
-  override suspend fun createBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
     val blob = storage.create(BlobInfo.newBuilder(bucketName, blobKey).build())
 
     blob.writer().use { byteChannel ->

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -29,8 +29,8 @@ interface StorageClient {
   /** Default size in bytes of each [Flow] value. */
   val defaultBufferSizeBytes: Int
 
-  /** Creates a blob with the specified key and content. */
-  suspend fun createBlob(blobKey: String, content: Flow<ByteString>): Blob
+  /** Writes [content] to a blob with [blobKey]. */
+  suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): Blob
 
   /** Returns a [Blob] for the specified key, or `null` if it cannot be found. */
   fun getBlob(blobKey: String): Blob?
@@ -52,11 +52,11 @@ interface StorageClient {
 }
 
 /**
- * [Creates][StorageClient.createBlob] a [StorageClient.Blob] using a [Flow] with [ByteString]s of
+ * [Writes][StorageClient.writeBlob] a [StorageClient.Blob] using a [Flow] with [ByteString]s of
  * [StorageClient.defaultBufferSizeBytes] size.
  */
-suspend fun StorageClient.createBlob(blobKey: String, content: ByteString) =
-  createBlob(blobKey, content.asBufferedFlow(defaultBufferSizeBytes))
+suspend fun StorageClient.writeBlob(blobKey: String, content: ByteString) =
+  writeBlob(blobKey, content.asBufferedFlow(defaultBufferSizeBytes))
 
 /**
  * [Reads][StorageClient.Blob.read] this [StorageClient.Blob]'s content using

--- a/src/main/kotlin/org/wfanet/measurement/storage/Store.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/Store.kt
@@ -54,7 +54,7 @@ protected constructor(
   suspend fun write(context: T, content: Flow<ByteString>): Blob {
     val blobKey = generateBlobKey(context)
     val privateBlobKey = "$blobKeyPrefix/$blobKey"
-    val createdBlob = storageClient.createBlob(privateBlobKey, content)
+    val createdBlob = storageClient.writeBlob(privateBlobKey, content)
     return Blob(blobKey, createdBlob)
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
@@ -21,21 +21,21 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.wfanet.measurement.common.consumeFirstOr
 import org.wfanet.measurement.internal.testing.BlobMetadata
-import org.wfanet.measurement.internal.testing.CreateBlobRequest
 import org.wfanet.measurement.internal.testing.DeleteBlobRequest
 import org.wfanet.measurement.internal.testing.DeleteBlobResponse
 import org.wfanet.measurement.internal.testing.ForwardedStorageGrpcKt.ForwardedStorageCoroutineImplBase as ForwardedStorageCoroutineService
 import org.wfanet.measurement.internal.testing.GetBlobMetadataRequest
 import org.wfanet.measurement.internal.testing.ReadBlobRequest
 import org.wfanet.measurement.internal.testing.ReadBlobResponse
+import org.wfanet.measurement.internal.testing.WriteBlobRequest
 
 /** [ForwardedStorageCoroutineService] implementation that uses [FileSystemStorageClient]. */
 class FileSystemStorageService(directory: File) : ForwardedStorageCoroutineService() {
   val storageClient: FileSystemStorageClient = FileSystemStorageClient(directory)
 
-  override suspend fun createBlob(requests: Flow<CreateBlobRequest>): BlobMetadata {
+  override suspend fun writeBlob(requests: Flow<WriteBlobRequest>): BlobMetadata {
     val blob =
-      requests.consumeFirstOr { CreateBlobRequest.getDefaultInstance() }.use { consumed ->
+      requests.consumeFirstOr { WriteBlobRequest.getDefaultInstance() }.use { consumed ->
         val headerRequest = consumed.item
         val blobKey = headerRequest.header.blobKey
         if (blobKey.isBlank()) {
@@ -43,7 +43,7 @@ class FileSystemStorageService(directory: File) : ForwardedStorageCoroutineServi
         }
 
         val content = consumed.remaining.map { it.bodyChunk.content }
-        storageClient.createBlob(blobKey, content)
+        storageClient.writeBlob(blobKey, content)
       }
 
     return BlobMetadata.newBuilder().setSize(blob.size).build()

--- a/src/main/proto/wfa/measurement/internal/testing/forwarded_storage_service.proto
+++ b/src/main/proto/wfa/measurement/internal/testing/forwarded_storage_service.proto
@@ -21,7 +21,7 @@ option java_multiple_files = true;
 
 // Blob storage which is forwarded over gRPC.
 service ForwardedStorage {
-  rpc CreateBlob(stream CreateBlobRequest) returns (BlobMetadata) {}
+  rpc WriteBlob(stream WriteBlobRequest) returns (BlobMetadata) {}
   rpc GetBlobMetadata(GetBlobMetadataRequest) returns (BlobMetadata) {}
   rpc ReadBlob(ReadBlobRequest) returns (stream ReadBlobResponse) {}
   rpc DeleteBlob(DeleteBlobRequest) returns (DeleteBlobResponse) {}
@@ -31,7 +31,7 @@ message BlobMetadata {
   int64 size = 1;
 }
 
-message CreateBlobRequest {
+message WriteBlobRequest {
   message Header {
     string blob_key = 1;
   }
@@ -55,7 +55,7 @@ message ReadBlobRequest {
 }
 
 message ReadBlobResponse {
-  bytes chunk = 2;
+  bytes chunk = 1;
 }
 
 message DeleteBlobRequest {

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClientTest.kt
@@ -33,10 +33,10 @@ import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
 import org.wfanet.measurement.common.size
 import org.wfanet.measurement.common.toByteArray
-import org.wfanet.measurement.storage.createBlob
 import org.wfanet.measurement.storage.read
 import org.wfanet.measurement.storage.testing.AbstractStorageClientTest
 import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+import org.wfanet.measurement.storage.writeBlob
 
 @RunWith(JUnit4::class)
 class KmsStorageClientTest : AbstractStorageClientTest<KmsStorageClient>() {
@@ -59,7 +59,7 @@ class KmsStorageClientTest : AbstractStorageClientTest<KmsStorageClient>() {
   fun `wrapped blob is encrypted`() = runBlocking {
     val blobKey = "kms-blob"
 
-    storageClient.createBlob(blobKey, testBlobContent)
+    storageClient.writeBlob(blobKey, testBlobContent)
 
     val wrappedBlob = assertNotNull(wrappedStorageClient.getBlob(blobKey))
     val plainTextContent =

--- a/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
@@ -39,7 +39,7 @@ class InMemoryStorageClientTest : AbstractStorageClientTest<InMemoryStorageClien
     val blobKey = "some-blob-key"
     val contents = "some-contents".toByteStringUtf8()
 
-    client.createBlob(blobKey, flowOf(contents))
+    client.writeBlob(blobKey, flowOf(contents))
 
     assertThat(client.contents.mapValues { it.value.read().flatten() })
       .containsExactly(blobKey, contents)


### PR DESCRIPTION
This renames StorageClient.createBlob to writeBlob, changing the documented semantics. Note that some StorageClient implementations such as GcsStorageClient already followed these semantics.

This more closely matches some of our current usage patterns w.r.t. handling incomplete writes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/90)
<!-- Reviewable:end -->
https://rally1.rallydev.com/#/?detail=/task/625602196713&fdp=true