### PR TITLE
Fix behavior of FakeKmsClient.doesSupport.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing/BUILD.bazel
@@ -13,6 +13,7 @@ kt_jvm_library(
         "@tink_java//src/main/java/com/google/crypto/tink:binary_keyset_reader",
         "@tink_java//src/main/java/com/google/crypto/tink:cleartext_keyset_handle",
         "@tink_java//src/main/java/com/google/crypto/tink:kms_client",
+        "@tink_java//src/main/java/com/google/crypto/tink:kms_clients",
         "@tink_java//src/main/java/com/google/crypto/tink:registry_cluster",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClientTest.kt
@@ -20,7 +20,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
-import com.google.crypto.tink.KmsClients
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
@@ -80,7 +79,7 @@ class KmsStorageClientTest : AbstractStorageClientTest<KmsStorageClient>() {
     private val aead = KEY_ENCRYPTION_KEY.getPrimitive(Aead::class.java)
 
     init {
-      KmsClients.add(FakeKmsClient().apply { addAead(KEK_URI, aead) })
+      FakeKmsClient.register(KEK_URI, aead)
     }
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/testing/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/testing/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+package(default_testonly = True)
+
+kt_jvm_test(
+    name = "FakeKmsClientTest",
+    srcs = ["FakeKmsClientTest.kt"],
+    test_class = "org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClientTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/org/junit",
+        "//imports/kotlin/kotlin/test",
+        "//src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing",
+        "@tink_java//src/main/java/com/google/crypto/tink:kms_clients",
+        "@tink_java//src/main/java/com/google/crypto/tink:kms_clients_test_util",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/testing/FakeKmsClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/testing/FakeKmsClientTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.crypto.tink.testing
+
+import com.google.common.truth.Truth.assertThat
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.KmsClients
+import com.google.crypto.tink.KmsClientsTestUtil
+import com.google.crypto.tink.aead.AeadConfig
+import java.security.GeneralSecurityException
+import kotlin.test.assertFailsWith
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [FakeKmsClient]. */
+@RunWith(JUnit4::class)
+class FakeKmsClientTest {
+  @Before
+  fun resetKmsClients() {
+    KmsClientsTestUtil.reset()
+  }
+
+  @Test
+  fun `registers client with AEAD for key URI`() {
+    val keyHandle = KeysetHandle.generateNew(AEAD_KEY_TEMPLATE)
+    val aead = keyHandle.getPrimitive(Aead::class.java)
+    val keyUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
+    val plainText = "lorem ipsum".toByteArray(Charsets.UTF_8)
+
+    FakeKmsClient.register(keyUri, aead)
+
+    val registeredAead = KmsClients.get(keyUri).getAead(keyUri)
+    val cipherText: ByteArray = aead.encrypt(plainText, null)
+    assertThat(registeredAead.decrypt(cipherText, null)).isEqualTo(plainText)
+  }
+
+  @Test
+  fun `does not register client for other key URIs`() {
+    val keyHandle = KeysetHandle.generateNew(AEAD_KEY_TEMPLATE)
+    val aead = keyHandle.getPrimitive(Aead::class.java)
+    val keyUri1 = FakeKmsClient.KEY_URI_PREFIX + "key1"
+    val keyUri2 = FakeKmsClient.KEY_URI_PREFIX + "key2"
+
+    FakeKmsClient.register(keyUri1, aead)
+
+    assertFailsWith<GeneralSecurityException> { KmsClients.get(keyUri2) }
+  }
+
+  companion object {
+    init {
+      AeadConfig.register()
+    }
+    private val AEAD_KEY_TEMPLATE = KeyTemplates.get("AES128_GCM")
+  }
+}


### PR DESCRIPTION
The method was incorrectly returning whether the key URI scheme is supported in general rather than whether the specific key URI is supported by the instance.

This also adds a register method to the companion object to parallel GcpKmsClient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/100)
<!-- Reviewable:end -->
