### PR TITLE
Parse SKID and AKID according to DER spec.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
@@ -296,6 +296,10 @@ fun File.readByteString(): ByteString {
   return inputStream().use { input -> ByteString.readFrom(input) }
 }
 
+fun Byte.toStringHex(): String {
+  return "%2x".format(this)
+}
+
 /** Converts a hex string to its equivalent [ByteString]. */
 @Deprecated(
   "Use HexString for stronger typing",

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -65,11 +65,13 @@ kt_jvm_library(
 kt_jvm_library(
     name = "security_provider",
     srcs = [
+        "DerEncoding.kt",
         "SecurityProvider.kt",
     ],
     deps = [
         "//imports/java/com/google/protobuf",
         "//imports/java/org/conscrypt",
+        "//src/main/kotlin/org/wfanet/measurement/common",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/DerEncoding.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/DerEncoding.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.crypto
+
+import com.google.protobuf.ByteString
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.cert.X509Certificate
+import kotlin.experimental.and
+import org.wfanet.measurement.common.toStringHex
+
+private const val SUBJECT_KEY_IDENTIFIER_OID = "2.5.29.14"
+private const val AUTHORITY_KEY_IDENTIFIER_OID = "2.5.29.35"
+
+private enum class Asn1TagClass {
+  UNIVERSAL,
+  APPLICATION,
+  CONTEXT_SPECIFIC,
+  PRIVATE;
+
+  companion object {
+    @OptIn(ExperimentalUnsignedTypes::class)
+    fun fromIdentifier(octet: Byte): Asn1TagClass =
+      when (val tagClass = octet.toUByte().toInt() ushr 6) {
+        0 -> UNIVERSAL
+        1 -> APPLICATION
+        2 -> CONTEXT_SPECIFIC
+        3 -> PRIVATE
+        else -> error("Failed to parse ASN.1 tag class from identifier octet $octet: $tagClass")
+      }
+  }
+}
+
+/** ASN.1 universal tags. */
+private enum class Asn1Tag(val byte: Byte) {
+  OCTET_STRING(0x04.toByte()),
+  SEQUENCE(0x10.toByte()),
+}
+
+/** ASN.1 context-specific tags for the X.509 v3 AuthorityKeyIdentifier extension. */
+private enum class AuthorityKeyIdentifierTag(val byte: Byte) {
+  KEY_IDENTIFIER(0x00.toByte()),
+}
+
+/**
+ * Descriptor for a definite-length DER-encoded value.
+ *
+ * See
+ * [A Layman's Guide to a Subset of ASN.1, BER, and DER](https://luca.ntop.org/Teaching/Appunti/asn1.html)
+ */
+private data class DefiniteLengthDescriptor(
+  val tagClass: Asn1TagClass,
+  /**
+   * ASN.1 tag number.
+   *
+   * Note that tag numbers above 30 (0x1E) are not supported.
+   */
+  val tagNumber: Byte,
+  val contentLength: Int,
+  val contentOffset: Int,
+) {
+  fun checkTag(universalTag: Asn1Tag) {
+    checkTag(Asn1TagClass.UNIVERSAL, universalTag.byte)
+  }
+
+  fun checkTag(tagClass: Asn1TagClass, tagNumber: Byte) {
+    check(this.tagClass == tagClass && this.tagNumber == tagNumber) {
+      val expectedTagNumber = "0x${tagNumber.toStringHex()}"
+      val actualTagNumber = "0x${this.tagNumber.toStringHex()}"
+      "Expected tag $expectedTagNumber with class $tagClass, " +
+        "actual tag $actualTagNumber with class ${this.tagClass}"
+    }
+  }
+
+  companion object {
+    private const val TAG_NUMBER_MASK = 0b0001_1111.toByte()
+    private const val LENGTH_OCTETS_MASK = 0b0111_1111.toByte()
+
+    fun parse(octets: ByteArray, offset: Int = 0): DefiniteLengthDescriptor {
+      val tagNumber: Byte = octets[offset] and TAG_NUMBER_MASK
+      check(tagNumber != TAG_NUMBER_MASK) { "High tag numbers not supported" }
+      val tagClass = Asn1TagClass.fromIdentifier(octets[offset])
+      val lengthIndex: Int = offset + 1
+
+      if (octets[lengthIndex].takeHighestOneBit() != 0b1000_0000.toByte()) {
+        // Short length form.
+        return DefiniteLengthDescriptor(
+          tagClass,
+          tagNumber,
+          octets[lengthIndex].toInt(),
+          lengthIndex + 1
+        )
+      }
+
+      val numAdditionalLengthOctets: Int = (octets[lengthIndex] and LENGTH_OCTETS_MASK).toInt()
+      check(numAdditionalLengthOctets <= 4) { "Lengths over 32 bits not supported" }
+      val buffer =
+        if (numAdditionalLengthOctets == 4) {
+          ByteBuffer.wrap(octets, lengthIndex + 1, 4)
+        } else {
+          // Pad buffer to 4 bytes.
+          ByteBuffer.allocate(4).apply {
+            repeat(4 - numAdditionalLengthOctets) { put(0x00) }
+            put(octets, lengthIndex + 1, numAdditionalLengthOctets)
+            flip()
+          }
+        }
+      return DefiniteLengthDescriptor(
+        tagClass,
+        tagNumber,
+        buffer.order(ByteOrder.BIG_ENDIAN).int,
+        lengthIndex + numAdditionalLengthOctets + 1
+      )
+    }
+  }
+}
+
+/**
+ * The keyIdentifier from the SubjectKeyIdentifier (SKI) X.509 extension, or `null` if it cannot be
+ * found.
+ */
+val X509Certificate.subjectKeyIdentifier: ByteString?
+  get() {
+    val octets: ByteArray = getExtensionValue(SUBJECT_KEY_IDENTIFIER_OID) ?: return null
+    val extensionInfo =
+      DefiniteLengthDescriptor.parse(octets).apply { checkTag(Asn1Tag.OCTET_STRING) }
+    val keyIdentifierInfo =
+      DefiniteLengthDescriptor.parse(octets, extensionInfo.contentOffset).apply {
+        checkTag(Asn1Tag.OCTET_STRING)
+      }
+    return ByteString.copyFrom(
+      octets,
+      keyIdentifierInfo.contentOffset,
+      keyIdentifierInfo.contentLength
+    )
+  }
+
+/**
+ * The keyIdentifier from the AuthorityKeyIdentifier (AKI) X.509 extension, or `null` if it cannot
+ * be found.
+ */
+val X509Certificate.authorityKeyIdentifier: ByteString?
+  get() {
+    val octets: ByteArray = getExtensionValue(AUTHORITY_KEY_IDENTIFIER_OID) ?: return null
+    val extensionInfo =
+      DefiniteLengthDescriptor.parse(octets).apply { checkTag(Asn1Tag.OCTET_STRING) }
+    val akidInfo =
+      DefiniteLengthDescriptor.parse(octets, extensionInfo.contentOffset).apply {
+        checkTag(Asn1Tag.SEQUENCE)
+      }
+    val sequenceElementInfo =
+      DefiniteLengthDescriptor.parse(octets, akidInfo.contentOffset).apply {
+        check(tagClass == Asn1TagClass.CONTEXT_SPECIFIC)
+      }
+
+    if (sequenceElementInfo.tagNumber != AuthorityKeyIdentifierTag.KEY_IDENTIFIER.byte) {
+      // keyIdentifier is an optional field in the AuthorityKeyIdentifier sequence.
+      return null
+    }
+    return ByteString.copyFrom(
+      octets,
+      sequenceElementInfo.contentOffset,
+      sequenceElementInfo.contentLength
+    )
+  }

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/SecurityProviderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/SecurityProviderTest.kt
@@ -52,29 +52,6 @@ private val SERVER_SKID =
     0x63,
     0xA8
   )
-private val CLIENT_SKID =
-  byteStringOf(
-    0x48,
-    0x32,
-    0x98,
-    0xE2,
-    0x03,
-    0xFE,
-    0xA1,
-    0xAF,
-    0xA0,
-    0x8D,
-    0x10,
-    0x7C,
-    0x92,
-    0x37,
-    0xCE,
-    0x19,
-    0x11,
-    0x6A,
-    0xA7,
-    0x8F,
-  )
 private val CLIENT_AKID =
   byteStringOf(
     0x57,
@@ -146,14 +123,9 @@ class SecurityProviderTest {
   }
 
   @Test
-  fun `subjectKeyIdentifier returns SKID of certificate with another format`() {
-    val certificate: X509Certificate = readCertificate(FIXED_CLIENT_CERT_PEM_FILE)
-
-    assertThat(certificate.subjectKeyIdentifier).isEqualTo(CLIENT_SKID)
-  }
-
-  @Test
-  fun `authorityKeyIdentifier returns AKID of certificate with another format`() {
+  fun `authorityKeyIdentifier returns AKID of certificate with long extension`() {
+    // Load a certificate whose AKI extension has all optional fields specified, resulting in an
+    // octet string that has a content length of >127 bytes.
     val certificate: X509Certificate = readCertificate(FIXED_CLIENT_CERT_PEM_FILE)
 
     assertThat(certificate.authorityKeyIdentifier).isEqualTo(CLIENT_AKID)


### PR DESCRIPTION
This includes a slight behavioral change to the subjectKeyIdentifier and authorityKeyIdentifier properties, where they will now throw an exception rather than returning null if parsing fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/102)
<!-- Reviewable:end -->
