### PR TITLE
Take in StorageClient instead of Store in SigningKeyStore constructor.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/HexString.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/HexString.kt
@@ -28,3 +28,5 @@ data class HexString(val bytes: ByteString) {
 
   override fun toString(): String = value
 }
+
+fun ByteString.toHexString() = HexString(this)

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyHandle.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyHandle.kt
@@ -28,6 +28,11 @@ data class SigningKeyHandle(val certificate: X509Certificate, private val privat
 
   fun newSigner(): Signature = privateKey.newSigner(certificate)
 
+  /**
+   * Writes this [SigningKeyHandle] to [keyStore].
+   *
+   * @return the blob key
+   */
   suspend fun write(keyStore: SigningKeyStore): String {
     return keyStore.write(certificate, privateKey)
   }

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStore.kt
@@ -17,19 +17,21 @@ package org.wfanet.measurement.common.crypto
 import com.google.protobuf.ByteString
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.wfanet.measurement.common.HexString
 import org.wfanet.measurement.common.flatten
+import org.wfanet.measurement.common.toHexString
+import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.Store
 
 /** Store of private signing keys. */
-class SigningKeyStore(private val store: Store<Context>) {
-  data class Context(val subjectKeyIdentifier: HexString) {
-    constructor(subjectKeyIdentifier: ByteString) : this(HexString(subjectKeyIdentifier))
+class SigningKeyStore(storageClient: StorageClient) {
+  private val store: Store<Context> = BlobStore(storageClient)
 
+  data class Context(val subjectKeyIdentifier: HexString) {
     val blobKey: String
-      get() = subjectKeyIdentifier.value
+      get() = subjectKeyIdentifier.value + ".pem"
+
+    constructor(subjectKeyIdentifier: ByteString) : this(subjectKeyIdentifier.toHexString())
 
     companion object {
       fun fromCertificate(certificate: X509Certificate): Context {
@@ -38,13 +40,20 @@ class SigningKeyStore(private val store: Store<Context>) {
     }
   }
 
+  private class BlobStore(storageClient: StorageClient) : Store<Context>(storageClient) {
+    override val blobKeyPrefix: String = "signing-keys"
+
+    override fun deriveBlobKey(context: Context): String = context.blobKey
+  }
+
   internal suspend fun write(certificate: X509Certificate, privateKey: PrivateKey): String {
     val pemBytes =
       ByteString.newOutput().use { output ->
-        val writer = PemWriter(output)
-        withContext(Dispatchers.IO) {
-          writer.write(certificate)
-          writer.write(privateKey)
+        PemWriter(output).apply {
+          @Suppress("BlockingMethodInNonBlockingContext") // Not blocking IO.
+          write(certificate)
+          @Suppress("BlockingMethodInNonBlockingContext") // Not blocking IO.
+          write(privateKey)
         }
         output.toByteString()
       }
@@ -52,12 +61,31 @@ class SigningKeyStore(private val store: Store<Context>) {
     return blob.blobKey
   }
 
-  suspend fun read(keyId: String): SigningKeyHandle? {
-    val blob = store.get(keyId) ?: return null
-    return PemReader(blob.read().flatten().newInput()).use { reader ->
-      val certificate = reader.readCertificate()
-      val privateKey = reader.readPrivateKeySpec().toPrivateKey(certificate.publicKey.algorithm)
-      SigningKeyHandle(certificate, privateKey)
+  /**
+   * Reads the [SigningKeyHandle] from [store] for the specified [blobContext].
+   *
+   * @return the [SigningKeyHandle], or `null` if not found
+   */
+  suspend fun read(blobContext: Context): SigningKeyHandle? {
+    return store.get(blobContext)?.readSigningKeyHandle()
+  }
+
+  /**
+   * Reads the [SigningKeyHandle] from [store] for the specified [blobKey].
+   *
+   * @return the [SigningKeyHandle], or `null` if not found
+   */
+  suspend fun read(blobKey: String): SigningKeyHandle? {
+    return store.get(blobKey)?.readSigningKeyHandle()
+  }
+
+  companion object {
+    private suspend fun Store.Blob.readSigningKeyHandle(): SigningKeyHandle {
+      return PemReader(read().flatten().newInput()).use { reader ->
+        val certificate = reader.readCertificate()
+        val privateKey = reader.readPrivateKeySpec().toPrivateKey(certificate.publicKey.algorithm)
+        SigningKeyHandle(certificate, privateKey)
+      }
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
@@ -19,7 +19,7 @@ import io.grpc.Server
 import io.grpc.ServerServiceDefinition
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.netty.NettyServerBuilder
-import io.grpc.services.HealthStatusManager
+import io.grpc.protobuf.services.HealthStatusManager
 import io.netty.handler.ssl.ClientAuth
 import io.netty.handler.ssl.SslContext
 import java.io.IOException

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/BUILD.bazel
@@ -64,7 +64,6 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
         "//src/main/kotlin/org/wfanet/measurement/storage:client",
         "//src/main/kotlin/org/wfanet/measurement/storage:store",
-        "//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
         "//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStoreTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/SigningKeyStoreTest.kt
@@ -18,51 +18,44 @@ import com.google.common.truth.Truth.assertThat
 import java.security.cert.X509Certificate
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.runBlocking
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE
 import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_KEY_FILE
 import org.wfanet.measurement.common.flatten
-import org.wfanet.measurement.storage.Store
-import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
+import org.wfanet.measurement.storage.testing.InMemoryStorageClient
 
 @RunWith(JUnit4::class)
 class SigningKeyStoreTest {
-  @get:Rule val tempDir = TemporaryFolder()
-
-  private lateinit var store: Store<SigningKeyStore.Context>
-  private lateinit var signingKeyStore: SigningKeyStore
-
-  @Before
-  fun initSigningKeyStore() {
-    val storageClient = FileSystemStorageClient(tempDir.root)
-    store =
-      object : Store<SigningKeyStore.Context>(storageClient) {
-        override val blobKeyPrefix: String = "sigKeys"
-
-        override fun deriveBlobKey(context: SigningKeyStore.Context): String = context.blobKey
-      }
-    signingKeyStore = SigningKeyStore(store)
-  }
+  private val storageClient = InMemoryStorageClient()
+  private val signingKeyStore = SigningKeyStore(storageClient)
 
   @Test
-  fun `write writes PEM file to store`() = runBlocking {
-    val keyId: String = SigningKeyHandle(certificate, privateKey).write(signingKeyStore)
+  fun `write writes PEM file to storage`() = runBlocking {
+    SigningKeyHandle(certificate, privateKey).write(signingKeyStore)
 
-    val blob = assertNotNull(store.get(keyId))
+    val blob = storageClient.contents.values.single()
     assertThat(blob.read().flatten().toStringUtf8()).isEqualTo(CONCATENATED_PEM)
   }
 
   @Test
-  fun `read reads signing key from store`() = runBlocking {
+  fun `read by blob context reads signing key from store`() = runBlocking {
     val privateKey = SigningKeyHandle(certificate, privateKey)
-    val keyId: String = privateKey.write(signingKeyStore)
+    privateKey.write(signingKeyStore)
 
-    val readKey: SigningKeyHandle = assertNotNull(signingKeyStore.read(keyId))
+    val readKey: SigningKeyHandle =
+      assertNotNull(signingKeyStore.read(SigningKeyStore.Context.fromCertificate(certificate)))
+
+    assertThat(readKey).isEqualTo(privateKey)
+  }
+
+  @Test
+  fun `read by blob key reads signing key from store`() = runBlocking {
+    val privateKey = SigningKeyHandle(certificate, privateKey)
+    val blobKey: String = privateKey.write(signingKeyStore)
+
+    val readKey: SigningKeyHandle = assertNotNull(signingKeyStore.read(blobKey))
 
     assertThat(readKey).isEqualTo(privateKey)
   }


### PR DESCRIPTION
SigningKeyStore initializes its private Store implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/103)
<!-- Reviewable:end -->
