### PR TITLE
improve Bytes.kt compatibilty for running from java 8 but compiling from java 11

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
@@ -18,6 +18,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import java.io.File
 import java.io.InputStream
+import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.channels.ReadableByteChannel
@@ -79,7 +80,8 @@ fun Long.toByteString(): ByteString {
 
 fun Long.toReadOnlyByteBuffer(): ByteBuffer {
   val buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(this)
-  buffer.flip()
+  // Cast to Buffer for Java 8 compatibility when compiled from Java 11
+  (buffer as Buffer).flip()
   return buffer.asReadOnlyBuffer()
 }
 
@@ -264,9 +266,10 @@ fun ReadableByteChannel.asFlow(bufferSize: Int): Flow<ByteString> {
 }
 
 private suspend fun FlowCollector<ByteString>.emitFrom(buffer: ByteBuffer) {
-  buffer.flip()
+  // Cast to Buffer for Java 8 compatibility when compiled from Java 11
+  (buffer as Buffer).flip()
   emit(buffer.toByteString())
-  buffer.clear()
+  (buffer as Buffer).clear()
 }
 
 /**


### PR DESCRIPTION
See https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/112)
<!-- Reviewable:end -->
