### PR TITLE
Fix duplicate definition of grpc-kotlin stub library.

### DIFF
--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -31,7 +31,11 @@ load(
 )
 load("//build/rules_proto:repo.bzl", "rules_proto_maven_artifacts_dict")
 load("//build/grpc_java:repo.bzl", "grpc_java_maven_artifacts_dict")
-load("//build/grpc_kotlin:repo.bzl", "grpc_kotlin_maven_artifacts_dict")
+load(
+    "//build/grpc_kotlin:repo.bzl",
+    "GRPC_KOTLIN_OVERRIDE_TARGETS",
+    "grpc_kotlin_maven_artifacts_dict",
+)
 load("//build/com_google_truth:repo.bzl", "com_google_truth_artifact_dict")
 load("//build/kotlinx_coroutines:repo.bzl", "kotlinx_coroutines_artifact_dict")
 load("//build/maven:artifacts.bzl", "artifacts")
@@ -103,7 +107,7 @@ def common_jvm_maven_artifacts_dict():
 
     return maven_artifacts
 
-COMMON_JVM_MAVEN_OVERRIDE_TARGETS = RULES_KOTLIN_OVERRIDE_TARGETS
+COMMON_JVM_MAVEN_OVERRIDE_TARGETS = dict(RULES_KOTLIN_OVERRIDE_TARGETS.items() + GRPC_KOTLIN_OVERRIDE_TARGETS.items())
 
 # Until the log2shell has been more widely mitigated, prohibit log4j totally.
 COMMON_JVM_EXCLUDED_ARTIFACTS = [

--- a/imports/kotlin/io/grpc/kotlin/BUILD.bazel
+++ b/imports/kotlin/io/grpc/kotlin/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "stub",
-    actual = "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:stub",
+    actual = "@maven//:io_grpc_grpc_kotlin_stub",
 )


### PR DESCRIPTION
GRPC_KOTLIN_OVERRIDE_TARGETS was not being included in the final override targets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/145)
<!-- Reviewable:end -->
