### PR TITLE
Revert "Remove runBlocking usage in Spanner AsyncDatabaseClient."

### DIFF
--- a/build/kotlinx_coroutines/repo.bzl
+++ b/build/kotlinx_coroutines/repo.bzl
@@ -18,7 +18,6 @@ load("//build:versions.bzl", "KOTLINX_COROUTINES_VERSION")
 
 _ARTIFACT_NAMES = [
     "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-    "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8",
     "org.jetbrains.kotlinx:kotlinx-coroutines-debug",
     "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
     "org.jetbrains.kotlinx:kotlinx-coroutines-test",

--- a/imports/kotlin/kotlinx/coroutines/BUILD.bazel
+++ b/imports/kotlin/kotlinx/coroutines/BUILD.bazel
@@ -4,8 +4,3 @@ alias(
     name = "core",
     actual = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
 )
-
-alias(
-    name = "jdk8",
-    actual = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_jdk8",
-)

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/common/BUILD.bazel
@@ -13,6 +13,5 @@ kt_jvm_library(
         "//imports/java/com/google/protobuf",
         "//imports/java/com/google/type:type_java_proto",
         "//imports/kotlin/kotlinx/coroutines:core",
-        "//imports/kotlin/kotlinx/coroutines:jdk8",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/common/Futures.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/common/Futures.kt
@@ -17,45 +17,25 @@ package org.wfanet.measurement.gcloud.common
 import com.google.api.core.ApiFuture
 import com.google.api.core.ApiFutureCallback
 import com.google.api.core.ApiFutures
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
-import java.util.concurrent.Future
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.future.future
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 
-object DirectExecutor : Executor {
-  override fun execute(command: Runnable) = command.run()
-}
-
-/** Suspends until the [ApiFuture] completes. */
-suspend fun <T> ApiFuture<T>.await(): T {
-  return suspendCoroutine { cont ->
-    val callback =
-      object : ApiFutureCallback<T> {
-        override fun onFailure(t: Throwable) {
-          cont.resumeWithException(t)
-        }
-
-        override fun onSuccess(result: T) {
-          cont.resume(result)
-        }
+/** Wraps the [ApiFuture] in a [Deferred] using the specified [executor]. */
+fun <T> ApiFuture<T>.asDeferred(executor: Executor): Deferred<T> {
+  val deferred = CompletableDeferred<T>()
+  ApiFutures.addCallback(
+    this,
+    object : ApiFutureCallback<T> {
+      override fun onFailure(e: Throwable) {
+        deferred.completeExceptionally(e)
       }
-    ApiFutures.addCallback(this, callback, DirectExecutor)
-  }
-}
 
-/** Starts a new coroutine as an [ApiFuture]. */
-fun <T> CoroutineScope.apiFuture(block: suspend CoroutineScope.() -> T): ApiFuture<T> {
-  return ForwardingApiFuture(future { block() })
-}
-
-private class ForwardingApiFuture<T>(private val delegate: CompletableFuture<T>) :
-  ApiFuture<T>, Future<T> by delegate {
-
-  override fun addListener(listener: Runnable, executor: Executor) {
-    delegate.whenCompleteAsync({ _, _ -> listener.run() }, executor)
-  }
+      override fun onSuccess(result: T) {
+        deferred.complete(result)
+      }
+    },
+    executor
+  )
+  return deferred
 }


### PR DESCRIPTION
Reverts world-federation-of-advertisers/common-jvm#150

Rollback reason: Introduces potential deadlocks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/155)
<!-- Reviewable:end -->
