### PR TITLE
Fix potential deadlock in Spanner AsyncDatabaseClient.

### DIFF
--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -40,7 +40,7 @@ load("//build/com_google_truth:repo.bzl", "com_google_truth_artifact_dict")
 load("//build/kotlinx_coroutines:repo.bzl", "kotlinx_coroutines_artifact_dict")
 load("//build/maven:artifacts.bzl", "artifacts")
 load("//build/tink:repo.bzl", "TINK_JAVA_KMS_MAVEN_DEPS")
-load("//build:versions.bzl", "PROTOBUF_VERSION")
+load("//build:versions.bzl", "PROTOBUF_KOTLIN_VERSION")
 
 # buildifier: disable=function-docstring-return
 def common_jvm_maven_artifacts():
@@ -69,7 +69,7 @@ def common_jvm_maven_artifacts_dict():
         "com.adobe.testing:s3mock-junit4": "2.2.3",
         "com.google.cloud:google-cloud-bigquery": "2.10.10",
         "com.google.cloud:google-cloud-nio": "0.123.28",
-        "com.google.cloud:google-cloud-spanner": "6.23.3",
+        "com.google.cloud:google-cloud-spanner": "6.27.0",
         "com.google.cloud:google-cloud-storage": "2.6.1",
         "com.google.guava:guava": "31.0.1-jre",
         "info.picocli:picocli": "4.4.0",
@@ -86,10 +86,10 @@ def common_jvm_maven_artifacts_dict():
         "com.opentable.components:otj-pg-embedded": "1.0.1",
 
         # Liquibase.
-        "org.liquibase:liquibase-core": "4.9.1",
+        "org.liquibase:liquibase-core": "4.15.0",
         "org.yaml:snakeyaml": "1.30",
-        "com.google.cloudspannerecosystem:liquibase-spanner": "4.6.1",
-        "com.google.cloud:google-cloud-spanner-jdbc": "2.6.4",
+        "com.google.cloudspannerecosystem:liquibase-spanner": "4.10.0",
+        "com.google.cloud:google-cloud-spanner-jdbc": "2.7.5",
         "org.liquibase.ext:liquibase-postgresql": "4.11.0",
 
         # For grpc-kotlin. This should be a version that is compatible with
@@ -97,7 +97,7 @@ def common_jvm_maven_artifacts_dict():
         "com.squareup:kotlinpoet": "1.8.0",
 
         # For kt_jvm_proto_library.
-        "com.google.protobuf:protobuf-kotlin": PROTOBUF_VERSION,
+        "com.google.protobuf:protobuf-kotlin": PROTOBUF_KOTLIN_VERSION,
 
         # Math library.
         "org.apache.commons:commons-math3": "3.6.1",

--- a/build/grpc_java/repo.bzl
+++ b/build/grpc_java/repo.bzl
@@ -46,7 +46,7 @@ def io_grpc_grpc_java():
     maybe(
         http_archive,
         name = "io_grpc_grpc_java",
-        sha256 = "c1b80883511ceb1e433fb2d4b2f6d85dca0c62a265a6a3e6695144610d6f65b8",
+        sha256 = "88b12b2b4e0beb849eddde98d5373f2f932513229dbf9ec86cc8e4912fc75e79",
         strip_prefix = "grpc-java-{version}".format(version = GRPC_JAVA_VERSION),
         url = "https://github.com/grpc/grpc-java/archive/refs/tags/v{version}.tar.gz".format(version = GRPC_JAVA_VERSION),
     )

--- a/build/rules_proto/repo.bzl
+++ b/build/rules_proto/repo.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//build:versions.bzl", "PROTOBUF_VERSION")
+load("//build:versions.bzl", "PROTOBUF_JAVA_VERSION")
 
 _MAVEN_COORDINATES = [
     "com.google.protobuf:protobuf-java",
@@ -36,4 +36,4 @@ def rules_proto():
     )
 
 def rules_proto_maven_artifacts_dict():
-    return {coordinates: PROTOBUF_VERSION for coordinates in _MAVEN_COORDINATES}
+    return {coordinates: PROTOBUF_JAVA_VERSION for coordinates in _MAVEN_COORDINATES}

--- a/build/versions.bzl
+++ b/build/versions.bzl
@@ -14,9 +14,13 @@
 
 """Version information for common dependencies."""
 
-GRPC_JAVA_VERSION = "1.46.0"
+GRPC_JAVA_VERSION = "1.48.1"
 GRPC_KOTLIN_VERSION = "1.3.0"
+
+# TODO(bazelbuild/rules_proto#136): Update to a newer version once fixed.
 PROTOBUF_VERSION = "3.20.1"
+PROTOBUF_JAVA_VERSION = PROTOBUF_VERSION
+PROTOBUF_KOTLIN_VERSION = PROTOBUF_JAVA_VERSION
 KOTLIN_LANGUAGE_LEVEL = "1.5"
 
 # Kotlin release version.

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/SpannerDatabaseConnector.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/SpannerDatabaseConnector.kt
@@ -35,12 +35,7 @@ class SpannerDatabaseConnector(
 
   val databaseId: DatabaseId = DatabaseId.of(projectName, instanceName, databaseName)
 
-  val databaseClient: AsyncDatabaseClient by lazy {
-    // Cloud Spanner Emulator currently only supports one read-write transaction at a time.
-    val maxTransactions = if (emulatorHost == null) 0 else 1
-
-    spanner.getAsyncDatabaseClient(databaseId, maxTransactions)
-  }
+  val databaseClient: AsyncDatabaseClient by lazy { spanner.getAsyncDatabaseClient(databaseId) }
 
   /**
    * Suspends until [databaseClient] is ready, throwing a

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing/SpannerEmulatorDatabaseRule.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing/SpannerEmulatorDatabaseRule.kt
@@ -53,10 +53,7 @@ class SpannerEmulatorDatabaseRule(
           val emulatorHost = runBlocking { emulator.start() }
           createDatabase(emulatorHost).use { spanner ->
             databaseClient =
-              spanner.getAsyncDatabaseClient(
-                DatabaseId.of(PROJECT, INSTANCE, databaseName),
-                MAX_READ_WRITE_TRANSACTIONS
-              )
+              spanner.getAsyncDatabaseClient(DatabaseId.of(PROJECT, INSTANCE, databaseName))
             base.evaluate()
           }
 
@@ -84,12 +81,5 @@ class SpannerEmulatorDatabaseRule(
   companion object {
     private const val PROJECT = "test-project"
     private const val INSTANCE = "test-instance"
-
-    /**
-     * Maximum number of simultanous read-write transactions to allow.
-     *
-     * The Cloud Spanner Emulator only supports one such transaction at a time.
-     */
-    private const val MAX_READ_WRITE_TRANSACTIONS: Int = 1
   }
 }


### PR DESCRIPTION
Limiting to a single transaction when using Spanner Emulator was masking an issue related to the Spanner client library's internal transaction retry logic. Aborted transactions should be retried[^1], but coroutine cancellation could prevent this from occurring.

[^1]: https://cloud.google.com/spanner/docs/transactions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/162)
<!-- Reviewable:end -->
