### PR TITLE
Update gRPC logging to include more information.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/ErrorLoggingServerInterceptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/ErrorLoggingServerInterceptor.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.grpc
+
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/** [ServerInterceptor] that logs unexpected gRPC errors. */
+object ErrorLoggingServerInterceptor : ServerInterceptor {
+  override fun <ReqT : Any, RespT : Any> interceptCall(
+    call: ServerCall<ReqT, RespT>,
+    headers: Metadata,
+    next: ServerCallHandler<ReqT, RespT>,
+  ): ServerCall.Listener<ReqT> {
+    val forwardingCall =
+      object : SimpleForwardingServerCall<ReqT, RespT>(call) {
+        override fun close(status: Status, trailers: Metadata) {
+          when (status.code) {
+            Status.Code.UNKNOWN,
+            Status.Code.INTERNAL -> {
+              val methodDescriptor = call.methodDescriptor
+              val threadName = Thread.currentThread().name
+              val message =
+                listOfNotNull(
+                    "[$threadName]",
+                    "gRPC error:",
+                    status.code.name,
+                    status.description,
+                  )
+                  .joinToString(" ")
+              logger.logp(
+                Level.WARNING,
+                methodDescriptor.serviceName,
+                methodDescriptor.bareMethodName,
+                message,
+                status.cause
+              )
+            }
+            else -> {}
+          }
+          super.close(status, trailers)
+        }
+      }
+
+    return next.startCall(forwardingCall, headers)
+  }
+
+  private val logger: Logger = Logger.getLogger(this::class.java.name)
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/LoggingServerInterceptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/LoggingServerInterceptor.kt
@@ -25,28 +25,51 @@ import io.grpc.ServerInterceptor
 import io.grpc.ServerInterceptors
 import io.grpc.ServerServiceDefinition
 import io.grpc.Status
+import java.util.concurrent.atomic.AtomicLong
 import java.util.logging.Level
 import java.util.logging.Logger
 import org.wfanet.measurement.common.truncateByteFields
 
 /** Logs all gRPC requests and responses. */
-class LoggingServerInterceptor : ServerInterceptor {
+object LoggingServerInterceptor : ServerInterceptor {
+  private val logger: Logger = Logger.getLogger(this::class.java.name)
+  private const val BYTES_TO_LOG = 100
+  private val threadName: String
+    get() = Thread.currentThread().name
+  private val requestCounter = AtomicLong()
+
   override fun <ReqT, RespT> interceptCall(
     call: ServerCall<ReqT, RespT>,
     headers: Metadata?,
     next: ServerCallHandler<ReqT, RespT>
   ): ServerCall.Listener<ReqT> {
-    val methodName = call.methodDescriptor.fullMethodName
+    val requestId = requestCounter.incrementAndGet()
+    val serviceName = call.methodDescriptor.serviceName
+    val methodName = call.methodDescriptor.bareMethodName
     val interceptedCall =
       object : SimpleForwardingServerCall<ReqT, RespT>(call) {
         override fun sendMessage(message: RespT) {
           val messageToLog = (message as Message).truncateByteFields(BYTES_TO_LOG)
-          logger.logp(Level.INFO, methodName, "gRPC response", "[$threadName] $messageToLog")
+          logger.logp(
+            Level.INFO,
+            serviceName,
+            methodName,
+            "[$threadName] gRPC $requestId response: $messageToLog"
+          )
           super.sendMessage(message)
         }
+
         override fun close(status: Status, trailers: Metadata) {
-          if (status.cause != null) {
-            logger.logp(Level.SEVERE, methodName, "gRPC exception", "[$threadName]", status.cause)
+          if (!status.isOk) {
+            val message =
+              listOfNotNull(
+                  "[$threadName]",
+                  "gRPC $requestId error:",
+                  status.code.name,
+                  status.description,
+                )
+                .joinToString(" ")
+            logger.logp(Level.INFO, serviceName, methodName, message, status.cause)
           }
           super.close(status, trailers)
         }
@@ -55,28 +78,34 @@ class LoggingServerInterceptor : ServerInterceptor {
     return object : SimpleForwardingServerCallListener<ReqT>(originalListener) {
       override fun onMessage(message: ReqT) {
         val messageToLog = (message as Message).truncateByteFields(BYTES_TO_LOG)
-        logger.logp(Level.INFO, methodName, "gRPC request", "[$threadName] $headers $messageToLog")
+        logger.logp(
+          Level.INFO,
+          serviceName,
+          methodName,
+          "[$threadName] gRPC $requestId request: $headers $messageToLog"
+        )
         super.onMessage(message)
+      }
+
+      override fun onComplete() {
+        logger.logp(Level.INFO, serviceName, methodName, "[$threadName] gRPC $requestId complete")
       }
     }
   }
-
-  companion object {
-    private val logger: Logger = Logger.getLogger(this::class.java.name)
-    private const val BYTES_TO_LOG = 100
-    private val threadName: String
-      get() = Thread.currentThread().name
-  }
 }
+
+/** Psuedo-constructor for backwards-compatibility. */
+@Deprecated("Use singleton object", ReplaceWith("LoggingServerInterceptor"))
+fun LoggingServerInterceptor() = LoggingServerInterceptor
 
 /** Logs all gRPC requests and responses. */
 fun BindableService.withVerboseLogging(enabled: Boolean = true): ServerServiceDefinition {
   if (!enabled) return this.bindService()
-  return ServerInterceptors.interceptForward(this, LoggingServerInterceptor())
+  return ServerInterceptors.interceptForward(this, LoggingServerInterceptor)
 }
 
 /** Logs all gRPC requests and responses. */
 fun ServerServiceDefinition.withVerboseLogging(enabled: Boolean = true): ServerServiceDefinition {
   if (!enabled) return this
-  return ServerInterceptors.interceptForward(this, LoggingServerInterceptor())
+  return ServerInterceptors.interceptForward(this, LoggingServerInterceptor)
 }


### PR DESCRIPTION
* Include a request ID.
* Log when an RPC is completed, as there is otherwise no indicator of such if an RPC has an empty response.
* Unconditionally log severe RPC errors on the server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/164)
<!-- Reviewable:end -->
