### PR TITLE
Restructure coroutine scopes for Spanner transactions.

### DIFF
--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -69,7 +69,7 @@ def common_jvm_maven_artifacts_dict():
         "com.adobe.testing:s3mock-junit4": "2.2.3",
         "com.google.cloud:google-cloud-bigquery": "2.10.10",
         "com.google.cloud:google-cloud-nio": "0.123.28",
-        "com.google.cloud:google-cloud-spanner": "6.34.1",
+        "com.google.cloud:google-cloud-spanner": "6.35.2",
         "com.google.cloud:google-cloud-storage": "2.6.1",
         "com.google.guava:guava": "31.0.1-jre",
         "info.picocli:picocli": "4.4.0",

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/SpannerDatabaseConnector.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/SpannerDatabaseConnector.kt
@@ -34,7 +34,6 @@ class SpannerDatabaseConnector(
   instanceName: String,
   databaseName: String,
   private val readyTimeout: Duration,
-  transactionTimeout: Duration,
   maxTransactionThreads: Int,
   emulatorHost: String?,
 ) : AutoCloseable {
@@ -66,7 +65,7 @@ class SpannerDatabaseConnector(
 
   val databaseId: DatabaseId = DatabaseId.of(projectName, instanceName, databaseName)
   val databaseClient: AsyncDatabaseClient by lazy {
-    spanner.getAsyncDatabaseClient(databaseId, transactionExecutor.value, transactionTimeout)
+    spanner.getAsyncDatabaseClient(databaseId, transactionExecutor.value)
   }
 
   /**
@@ -116,7 +115,6 @@ private fun SpannerFlags.toSpannerDatabaseConnector(): SpannerDatabaseConnector 
     instanceName = instanceName,
     databaseName = databaseName,
     readyTimeout = readyTimeout,
-    transactionTimeout = transactionTimeout,
     maxTransactionThreads = maxTransactionThreads,
     emulatorHost = emulatorHost,
   )


### PR DESCRIPTION
Breaking API change: TransactionWork no longer takes a TransactionContext parameter, and instead is run with a TransactionScope receiver. This TransactionScope extends CoroutineScope so that CoroutineScope extension functions called from TransactionWork will be run in the TransactionScope.

This also drops the unnecessary transaction timeout, instead expecting callers to implement their own timeouts as necessary.

This is for world-federation-of-advertisers/cross-media-measurement#840

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/common-jvm/179)
<!-- Reviewable:end -->
