### PR TITLE
Update the build/test environment to 20.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build-test:
     name: Build and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out revision
         uses: actions/checkout@v2


### PR DESCRIPTION
18.04 is being turned down 2023-04-01 and will be offline on and off until then.