### PR TITLE
Update rules_docker to 0.25.0.

### DIFF
--- a/build/io_bazel_rules_docker/base_images.bzl
+++ b/build/io_bazel_rules_docker/base_images.bzl
@@ -25,22 +25,22 @@ def base_java_images():
     See https://console.cloud.google.com/gcr/images/distroless/GLOBAL/java
 
     We currently use
-    gcr.io/distroless/java11-debian11:nonroot
+    gcr.io/distroless/java:11-nonroot
     and
-    gcr.io/distroless/java11-debian11:debug-nonroot
+    gcr.io/distroless/java:11-debug-nonroot
     as the base images.
     """
 
     container_pull(
         name = "java_image_base",
-        digest = "sha256:a9be9ef912e263a1cf386a91648ee2454b892e5607ddf285875a5c4e2b0079b3",
+        digest = "sha256:350d756ddcaf819b582ba6a58c4425a1db78e5798e53355f04a235cd7e0da4eb",
         registry = "gcr.io",
-        repository = "distroless/java11-debian11",
+        repository = "distroless/java",
     )
 
     container_pull(
         name = "java_debug_image_base",
-        digest = "sha256:b33c5d712678985705cd85d884daf4444333a00f590fc7c48a7b8165c5a902a8",
+        digest = "sha256:817930976e739c52dffc9fc7ee37dbdfc1125639db90ab9c9aab62f793a9aa9a",
         registry = "gcr.io",
-        repository = "distroless/java11-debian11",
+        repository = "distroless/java",
     )

--- a/build/io_bazel_rules_docker/repo.bzl
+++ b/build/io_bazel_rules_docker/repo.bzl
@@ -14,41 +14,7 @@
 
 """Repository rules/macros for rules_docker."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-_RELEASE_URL = "https://github.com/bazelbuild/rules_docker/releases/download/v{version}/rules_docker-v{version}.tar.gz"
-_ARCHIVE_URL = "https://github.com/bazelbuild/rules_docker/archive/{commit}.tar.gz"
-
-def _rules_docker_repo(sha256, version = None, commit = None, name = "io_bazel_rules_docker"):
-    """Repository rule for rules_docker.
-
-    Args:
-        name: Target name.
-        version: Release version, e.g. "0.14.4". Mutually exclusive with commit.
-        commit: Commit hash. Mutually exclusive with version.
-        sha256: SHA256 hash of the source.
-
-    See https://github.com/bazelbuild/rules_docker
-    """
-    if version:
-        suffix = version
-        url = _RELEASE_URL.format(version = version)
-    else:
-        suffix = commit
-        url = _ARCHIVE_URL.format(commit = commit)
-
-    maybe(
-        http_archive,
-        name = name,
-        sha256 = sha256,
-        strip_prefix = "rules_docker-" + suffix,
-        urls = [url],
-    )
+load("//build:versions.bzl", "RULES_DOCKER", "versioned_http_archive")
 
 def io_bazel_rules_docker():
-    _rules_docker_repo(
-        name = "io_bazel_rules_docker",
-        commit = "f929d80c5a4363994968248d87a892b1c2ef61d4",
-        sha256 = "efda18e39a63ee3c1b187b1349f61c48c31322bf84227d319b5dece994380bb6",
-    )
+    versioned_http_archive(RULES_DOCKER, "io_bazel_rules_docker")

--- a/build/versions.bzl
+++ b/build/versions.bzl
@@ -35,6 +35,8 @@ def _format_url_templates(versioned_archive):
     ]
 
 def _format_prefix(versioned_archive):
+    if not hasattr(versioned_archive, "prefix_template"):
+        return None
     return versioned_archive.prefix_template.format(
         version = versioned_archive.version,
     )
@@ -91,6 +93,14 @@ SPANNER_EMULATOR = VersionedArchiveInfo(
     sha256 = "0716bf95e740328cdaef7a7e41e022037fde803596378a9db81b56bc0de1dcb9",
     url_templates = [
         "https://storage.googleapis.com/cloud-spanner-emulator/releases/{version}/cloud-spanner-emulator_linux_amd64-{version}.tar.gz",
+    ],
+)
+
+RULES_DOCKER = VersionedArchiveInfo(
+    version = "0.25.0",
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    url_templates = [
+        "https://github.com/bazelbuild/rules_docker/releases/download/v{version}/rules_docker-v{version}.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This also updates the base Distroless Java images to the latest release.