### PR TITLE
Pulling out grpc_extra_deps and updating the go_register_toolchains version

### DIFF
--- a/build/common_jvm_extra_deps.bzl
+++ b/build/common_jvm_extra_deps.bzl
@@ -24,7 +24,7 @@ load(
     "@io_bazel_rules_docker//java:image.bzl",
     java_image_repositories = "repositories",
 )
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+load("//build:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 def common_jvm_extra_deps():
     """

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -1,0 +1,78 @@
+# Copyright 2023 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl.
+File modified from here: https://github.com/grpc/grpc/blob/master/bazel/grpc_extra_deps.bzl
+Need to update the go_register_toolchains version.
+"""
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+load("@com_envoyproxy_protoc_gen_validate//:dependencies.bzl", "go_third_party")
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+
+def grpc_extra_deps(ignore_version_differences = False):
+    """Loads the extra dependencies.
+
+    These are necessary for using the external repositories defined in
+    grpc_deps.bzl. Projects that depend on gRPC as an external repository need
+    to call both grpc_deps and grpc_extra_deps, if they have not already loaded
+    the extra dependencies. For example, they can do the following in their
+    WORKSPACE
+    ```
+    load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
+    grpc_deps()
+
+    grpc_test_only_deps()
+
+    load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+    grpc_extra_deps()
+    ```
+
+    Args:
+      ignore_version_differences: Plumbed directly to the invocation of
+        apple_rules_dependencies.
+    """
+    protobuf_deps()
+
+    upb_deps()
+
+    api_dependencies()
+
+    go_rules_dependencies()
+    go_register_toolchains(version = "1.19.4")
+    gazelle_dependencies()
+
+    # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is
+    # needed for building C++ xDS protos
+    go_third_party()
+
+    apple_rules_dependencies(ignore_version_differences = ignore_version_differences)
+
+    apple_support_dependencies()
+
+    # Initialize Google APIs with only C++ and Python targets
+    switched_rules_by_language(
+        name = "com_google_googleapis_imports",
+        cc = True,
+        grpc = True,
+        python = True,
+    )

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -32,8 +32,7 @@ def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = 
     with modifications to address version compatibility issues.
     It must be run after `grpc_deps`.
 
-    TODO(https://github.com/grpc/grpc/issues/32850):
-    Revert when the dependency issue is addressed.
+    TODO(grpc/grpc#32850): Revert when the dependency issue is addressed.
 
     Args:
       ignore_version_differences: Plumbed directly to the invocation of

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl.
-
+"""Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl.
+"""
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl.
-"""
+# Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl.
+
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
@@ -29,10 +28,12 @@ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = "1.19.4"):
     """Loads additional gRPC dependencies.
 
-    This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues.
+    This is copied from https://github.com/grpc/grpc
+    with modifications to address version compatibility issues.
     It must be run after `grpc_deps`.
 
-    TODO(https://github.com/grpc/grpc/issues/32850): Revert when the dependency issue is addressed.
+    TODO(https://github.com/grpc/grpc/issues/32850):
+    Revert when the dependency issue is addressed.
 
     Args:
       ignore_version_differences: Plumbed directly to the invocation of

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -26,7 +26,7 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 
-def grpc_extra_deps(ignore_version_differences = False, go_toolchanins_version = "1.19.4"):
+def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = "1.19.4"):
     """Loads additional gRPC dependencies.
 
     This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues.
@@ -60,7 +60,7 @@ def grpc_extra_deps(ignore_version_differences = False, go_toolchanins_version =
     api_dependencies()
 
     go_rules_dependencies()
-    go_register_toolchains(version = go_toolchanins_version)
+    go_register_toolchains(version = go_toolchains_version)
     gazelle_dependencies()
 
     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -52,6 +52,8 @@ def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = 
     Args:
       ignore_version_differences: Plumbed directly to the invocation of
         apple_rules_dependencies.
+      go_toolchains_version: Plumbed directly to the invocation of 
+        go_register_toolchains.
     """
     protobuf_deps()
 

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -28,9 +28,9 @@ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 
 def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = "1.19.4"):
     """Loads additional gRPC dependencies.
-    
+
     This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues. It must be run after `grpc_deps`.
-    
+
     TODO(https://github.com/grpc/grpc/issues/32850): Revert when the dependency issue is addressed.
 
     Args:

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -29,7 +29,8 @@ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = "1.19.4"):
     """Loads additional gRPC dependencies.
 
-    This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues. It must be run after `grpc_deps`.
+    This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues.
+    It must be run after `grpc_deps`.
 
     TODO(https://github.com/grpc/grpc/issues/32850): Revert when the dependency issue is addressed.
 

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -14,8 +14,6 @@
 
 """
 Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl.
-File modified from here: https://github.com/grpc/grpc/blob/master/bazel/grpc_extra_deps.bzl
-Need to update the go_register_toolchains version.
 """
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
@@ -28,8 +26,10 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 
-def grpc_extra_deps(ignore_version_differences = False):
-    """Loads the extra dependencies.
+def grpc_extra_deps(ignore_version_differences = False, go_toolchanins_version = "1.19.4"):
+    """Loads additional gRPC dependencies.
+
+    This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues.
 
     These are necessary for using the external repositories defined in
     grpc_deps.bzl. Projects that depend on gRPC as an external repository need
@@ -42,7 +42,9 @@ def grpc_extra_deps(ignore_version_differences = False):
 
     grpc_test_only_deps()
 
-    load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+    # load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+    load("//build/grpc_extra_deps.bzl", "grpc_extra_deps")
+    TODO(https://github.com/grpc/grpc/issues/32850): Revert when the dependency issue is addressed.
 
     grpc_extra_deps()
     ```
@@ -58,7 +60,7 @@ def grpc_extra_deps(ignore_version_differences = False):
     api_dependencies()
 
     go_rules_dependencies()
-    go_register_toolchains(version = "1.19.4")
+    go_register_toolchains(version = go_toolchanins_version)
     gazelle_dependencies()
 
     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -37,7 +37,7 @@ def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = 
     Args:
       ignore_version_differences: Plumbed directly to the invocation of
         apple_rules_dependencies.
-      go_toolchains_version: Plumbed directly to the invocation of 
+      go_toolchains_version: Plumbed directly to the invocation of
         go_register_toolchains.
     """
     protobuf_deps()

--- a/build/grpc_extra_deps.bzl
+++ b/build/grpc_extra_deps.bzl
@@ -28,26 +28,10 @@ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 
 def grpc_extra_deps(ignore_version_differences = False, go_toolchains_version = "1.19.4"):
     """Loads additional gRPC dependencies.
-
-    This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues.
-
-    These are necessary for using the external repositories defined in
-    grpc_deps.bzl. Projects that depend on gRPC as an external repository need
-    to call both grpc_deps and grpc_extra_deps, if they have not already loaded
-    the extra dependencies. For example, they can do the following in their
-    WORKSPACE
-    ```
-    load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
-    grpc_deps()
-
-    grpc_test_only_deps()
-
-    # load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
-    load("//build/grpc_extra_deps.bzl", "grpc_extra_deps")
+    
+    This is copied from https://github.com/grpc/grpc with modifications to address version compatibility issues. It must be run after `grpc_deps`.
+    
     TODO(https://github.com/grpc/grpc/issues/32850): Revert when the dependency issue is addressed.
-
-    grpc_extra_deps()
-    ```
 
     Args:
       ignore_version_differences: Plumbed directly to the invocation of


### PR DESCRIPTION
In the CMM repo, we want to add a GRPC Gateway for the BFF Reporting API to support the Reporting UI. GRPC Gateway requires to call `go_register_toolchains(version = "1.19.4")`. Or at least trying to change things to support the hardcoded version in the dependency would be difficult. The rest of the file is the same to minimize the risk of breaking anything.