### PR TITLE
add method to return tink_cc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,6 @@ load(
     "COMMON_JVM_MAVEN_OVERRIDE_TARGETS",
     "common_jvm_maven_artifacts",
 )
-
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(

--- a/build/tink/repo.bzl
+++ b/build/tink/repo.bzl
@@ -49,6 +49,24 @@ def tink_java():
         strip_prefix = "tink-{commit}/java_src".format(commit = TINK_COMMIT),
     )
 
+def tink_cc():
+    _tink_base()
+
+    maybe(
+        http_archive,
+        name = "tink_cc",
+        url = _URL,
+        sha256 = _SHA256,
+        strip_prefix = "tink-{commit}/cc".format(commit = TINK_COMMIT),
+        repo_mapping = {
+            # TODO(bazelbuild/rules_proto#121): Remove this once
+            # protobuf_workspace is fixed.
+            "@com_google_protobuf": "@com_github_protocolbuffers_protobuf",
+        },
+    )
+    _tink_base()
+
+
 def _tink_base():
     maybe(
         http_archive,


### PR DESCRIPTION
Add method to ```repo.bzl``` to add tink_cc repo 

N.B. Rather than making _tink_base public and accessible from cross-media-measurement, this PR expose a new public method ```tink_cc``` to load the repo