### PR TITLE
Add byteOrder param to functions that convert between Longs and bytes.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
@@ -69,17 +69,29 @@ fun Iterable<ByteString>.toByteArray(): ByteArray {
 val ByteString.size: Int
   get() = size()
 
-fun ByteString.toLong(): Long {
+fun ByteString.toLong(byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN): Long {
   require(size == 8) { "Expected 8 bytes, got $size" }
-  return asReadOnlyByteBuffer().long
+  return asReadOnlyByteBuffer().order(byteOrder).long
 }
 
-fun Long.toByteString(): ByteString {
-  return ByteString.copyFrom(toReadOnlyByteBuffer())
+/**
+ * Converts this [Long] to a [ByteString].
+ *
+ * @param byteOrder the byte order to use when converting the [Long] to bytes
+ */
+fun Long.toByteString(byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN): ByteString {
+  return ByteString.copyFrom(toReadOnlyByteBuffer(byteOrder))
 }
 
-fun Long.toReadOnlyByteBuffer(): ByteBuffer {
-  val buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(this)
+/**
+ * Converts this [Long] to a [ByteBuffer].
+ *
+ * @param byteOrder the byte order to use when converting the [Long] to bytes. Note that this does
+ *   not affect the [order][ByteBuffer.order] of the returned [ByteBuffer], which is always
+ *   [ByteOrder.BIG_ENDIAN].
+ */
+fun Long.toReadOnlyByteBuffer(byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN): ByteBuffer {
+  val buffer = ByteBuffer.allocate(8).order(byteOrder).putLong(this)
   buffer.flip()
   return buffer.asReadOnlyBuffer()
 }

--- a/src/test/kotlin/org/wfanet/measurement/common/BytesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/BytesTest.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.common
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
+import java.nio.ByteOrder
 import kotlin.test.assertFails
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -33,6 +34,15 @@ class BytesTest {
 
     assertThat(longValue.toByteString()).isEqualTo(binaryValue)
     assertThat(binaryValue.toLong()).isEqualTo(longValue)
+  }
+
+  @Test
+  fun `ByteString is bidirectionally convertible with Long using little endian`() {
+    val longValue = -3519155157501101422L
+    val binaryValue = HexString("92BAA98F077329CF").bytes
+
+    assertThat(longValue.toByteString(ByteOrder.LITTLE_ENDIAN)).isEqualTo(binaryValue)
+    assertThat(binaryValue.toLong(ByteOrder.LITTLE_ENDIAN)).isEqualTo(longValue)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/HashingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/HashingTest.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.common.crypto
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
+import java.nio.ByteOrder
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -25,7 +26,7 @@ import org.wfanet.measurement.common.HexString
 class HashingTest {
   @Test
   fun `hashSha256 get expected result`() {
-    val result = hashSha256(ByteString.copyFromUtf8("foo"))
+    val result = Hashing.hashSha256(ByteString.copyFromUtf8("foo"))
     assertThat(HexString(result))
       .isEqualTo(HexString("2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE"))
   }
@@ -34,9 +35,20 @@ class HashingTest {
   fun `hashSha256 get expected result for Long`() {
     val signedFixed64 = -5720240472533425799L // Hex: B09D9F98ECD52179
 
-    val result = hashSha256(signedFixed64)
+    val result = Hashing.hashSha256(signedFixed64)
 
     // Compare to value obtained using `echo 'B09D9F98ECD52179' | xxd -r -p | sha256sum`
+    assertThat(HexString(result))
+      .isEqualTo(HexString("5258F08862A1715F8D95B310D0D509A88EC1FD79BF1F512DD4350961659E9884"))
+  }
+
+  @Test
+  fun `hashSha256 get expected result for little endian Long`() {
+    val signedFixed64 = 8728492764970327472 // Hex: 7921D5EC989F9DB0
+
+    val result = Hashing.hashSha256(signedFixed64, ByteOrder.LITTLE_ENDIAN)
+
+    // Compare to value obtained using `echo '7921D5EC989F9DB0' | xxd -e -r -p | sha256sum`
     assertThat(HexString(result))
       .isEqualTo(HexString("5258F08862A1715F8D95B310D0D509A88EC1FD79BF1F512DD4350961659E9884"))
   }


### PR DESCRIPTION
This also moves non-extension hashing functions into a `Hashing` object per the style guide. The top-level versions are marked as deprecated.