### PR TITLE
Add functions to convert proto timestamp to date and viceversa

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/ProtoUtils.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ProtoUtils.kt
@@ -132,18 +132,13 @@ fun Message.Builder.mergeFromTextProto(textProto: Readable, typeRegistry: TypeRe
 }
 
 /** Converts this [Timestamp] to a [Date]. */
-fun Timestamp.toProtoDate(): Date {
+fun Timestamp.toDateUtc(): Date {
   return toInstant().atZone(ZoneOffset.UTC).toLocalDate().toProtoDate()
 }
 
 /** Converts this [Date] to a [Timestamp]. */
-fun Date.toProtoTime(): Timestamp {
+fun Date.atStartOfDayUtc(): Timestamp {
   return toLocalDate().atStartOfDay().toInstant(ZoneOffset.UTC).toProtoTime()
-}
-
-/** Converts this [Instant] to a [Date] */
-private fun Instant.toDate(): Date {
-  return this.atZone(ZoneOffset.UTC).toLocalDate().toProtoDate()
 }
 
 @Suppress("UNCHECKED_CAST") // Safe per Message contract.

--- a/src/main/kotlin/org/wfanet/measurement/common/ProtoUtils.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ProtoUtils.kt
@@ -26,12 +26,14 @@ import com.google.protobuf.TypeRegistry
 import com.google.protobuf.duration
 import com.google.protobuf.timestamp
 import com.google.protobuf.util.JsonFormat
+import com.google.type.Date
 import com.google.type.Interval
 import com.google.type.interval
 import java.io.File
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneOffset
 
 /** Converts a protobuf [MessageOrBuilder] into its canonical JSON representation. */
 fun MessageOrBuilder.toJson(): String {
@@ -127,6 +129,21 @@ val ProtocolMessageEnum.numberAsLong: Long
 
 fun Message.Builder.mergeFromTextProto(textProto: Readable, typeRegistry: TypeRegistry) {
   TextFormat.Parser.newBuilder().setTypeRegistry(typeRegistry).build().merge(textProto, this)
+}
+
+/** Converts this [Timestamp] to a [Date]. */
+fun Timestamp.toProtoDate(): Date {
+  return toInstant().atZone(ZoneOffset.UTC).toLocalDate().toProtoDate()
+}
+
+/** Converts this [Date] to a [Timestamp]. */
+fun Date.toProtoTime(): Timestamp {
+  return toLocalDate().atStartOfDay().toInstant(ZoneOffset.UTC).toProtoTime()
+}
+
+/** Converts this [Instant] to a [Date] */
+private fun Instant.toDate(): Date {
+  return this.atZone(ZoneOffset.UTC).toLocalDate().toProtoDate()
 }
 
 @Suppress("UNCHECKED_CAST") // Safe per Message contract.


### PR DESCRIPTION
Add function to convert Instant to a Date

[#1123](https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/1123) depends on this