### PR TITLE
Do not call exitProcess from commandLineMain on non-zero status.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/CommandLines.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/CommandLines.kt
@@ -27,7 +27,10 @@ import picocli.CommandLine
  * @param args command-line arguments
  */
 fun commandLineMain(command: KFunction<*>, args: Array<String>) {
-  exitProcess(command.toCommandLine().execute(*args))
+  val status: Int = command.toCommandLine().execute(*args)
+  if (status != 0) {
+    exitProcess(status)
+  }
 }
 
 /**
@@ -41,7 +44,10 @@ fun commandLineMain(
   args: Array<String>,
   format: DurationFormat = DurationFormat.HUMAN_READABLE
 ) {
-  exitProcess(command.toCommandLine(format).execute(*args))
+  val status: Int = command.toCommandLine(format).execute(*args)
+  if (status != 0) {
+    exitProcess(status)
+  }
 }
 
 private fun KFunction<*>.toCommandLine(): CommandLine {

--- a/src/main/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
@@ -12,10 +12,10 @@ kt_jvm_library(
         "//imports/kotlin/kotlin:stdlib_jdk7",
     ],
     deps = [
+        "//imports/java/com/google/common/truth",
         "//imports/java/com/google/common/truth/extensions/proto",
         "//imports/java/com/google/protobuf",
         "//imports/java/org/junit",
-        "//imports/kotlin/kotlin/test",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//imports/kotlin/kotlinx/coroutines:jdk8",
         "//imports/kotlin/org/mockito/kotlin",

--- a/src/test/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/testing/BUILD.bazel
@@ -14,7 +14,6 @@ kt_jvm_test(
 kt_jvm_test(
     name = "CommandLineTestingTest",
     srcs = ["CommandLineTestingTest.kt"],
-    associates = ["//src/main/kotlin/org/wfanet/measurement/common/testing:testing"],
     jvm_flags = ["-Dcom.google.testing.junit.runner.shouldInstallTestSecurityManager=false"],
     test_class = "org.wfanet.measurement.common.testing.CommandLineTestingTest",
     deps = [
@@ -22,5 +21,6 @@ kt_jvm_test(
         "//imports/java/org/junit",
         "//imports/java/picocli",
         "//imports/kotlin/kotlin/test",
+        "//src/main/kotlin/org/wfanet/measurement/common/testing",
     ],
 )


### PR DESCRIPTION
This addresses a bug where command line tests may appear to pass without actually running any tests. This results in breaking changes to the CommandLineTesting util.