### PR TITLE
Update Postgres dependencies for Google Cloud SQL

### DIFF
--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -91,8 +91,8 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.15.2",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.15.2",
+        "com.google.cloud.sql:postgres-socket-factory": "1.13.1",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.13.1",
         "org.postgresql:postgresql": "42.7.1",
         "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
         "org.testcontainers:postgresql": "1.19.4",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -73,6 +73,8 @@ def common_jvm_maven_artifacts_dict():
     # or default dependency versions).
     maven_artifacts.update({
         "com.adobe.testing:s3mock-junit4": "2.2.3",
+        "com.google.apis:google-api-services-storage": "v1-rev20240105-2.0.0",
+        "com.google.apis:google-api-services-sqladmin": "v1-rev20240101-2.0.0",
         "com.google.cloud:google-cloud-bigquery": "2.10.10",
         "com.google.cloud:google-cloud-nio": "0.123.28",
         "com.google.cloud:google-cloud-spanner": "6.35.2",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -91,8 +91,8 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.10.0",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.10.0",
+        "com.google.cloud.sql:postgres-socket-factory": "1.11.2",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.11.2",
         "org.postgresql:postgresql": "42.7.1",
         "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
         "org.testcontainers:postgresql": "1.19.4",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -91,8 +91,8 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.13.1",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.13.1",
+        "com.google.cloud.sql:postgres-socket-factory": "1.10.0",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.10.0",
         "org.postgresql:postgresql": "42.7.1",
         "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
         "org.testcontainers:postgresql": "1.19.4",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -91,8 +91,8 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.11.2",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.11.2",
+        "com.google.cloud.sql:postgres-socket-factory": "1.12.0",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.12.0",
         "org.postgresql:postgresql": "42.7.1",
         "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
         "org.testcontainers:postgresql": "1.19.4",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -91,8 +91,8 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.12.0",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.12.0",
+        "com.google.cloud.sql:postgres-socket-factory": "1.13.0",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.13.0",
         "org.postgresql:postgresql": "42.7.1",
         "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
         "org.testcontainers:postgresql": "1.19.4",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -91,8 +91,8 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.13.0",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.13.0",
+        "com.google.cloud.sql:postgres-socket-factory": "1.12.0",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.12.0",
         "org.postgresql:postgresql": "42.7.1",
         "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
         "org.testcontainers:postgresql": "1.19.4",

--- a/build/common_jvm_maven.bzl
+++ b/build/common_jvm_maven.bzl
@@ -73,8 +73,6 @@ def common_jvm_maven_artifacts_dict():
     # or default dependency versions).
     maven_artifacts.update({
         "com.adobe.testing:s3mock-junit4": "2.2.3",
-        "com.google.apis:google-api-services-storage": "v1-rev20240105-2.0.0",
-        "com.google.apis:google-api-services-sqladmin": "v1-rev20240101-2.0.0",
         "com.google.cloud:google-cloud-bigquery": "2.10.10",
         "com.google.cloud:google-cloud-nio": "0.123.28",
         "com.google.cloud:google-cloud-spanner": "6.35.2",
@@ -93,11 +91,11 @@ def common_jvm_maven_artifacts_dict():
         "software.amazon.awssdk:regions": AWS_JAVA_SDK_VERSION,
 
         # PostgreSQL.
-        "com.google.cloud.sql:postgres-socket-factory": "1.6.2",
-        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.6.2",
-        "org.postgresql:postgresql": "42.4.0",
-        "org.postgresql:r2dbc-postgresql": "0.9.1.RELEASE",
-        "org.testcontainers:postgresql": "1.18.3",
+        "com.google.cloud.sql:postgres-socket-factory": "1.15.2",
+        "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres": "1.15.2",
+        "org.postgresql:postgresql": "42.7.1",
+        "org.postgresql:r2dbc-postgresql": "1.0.4.RELEASE",
+        "org.testcontainers:postgresql": "1.19.4",
 
         # Liquibase.
         "org.yaml:snakeyaml": "1.30",


### PR DESCRIPTION
This updates Postgres dependencies to avoid world-federation-of-advertisers/cross-media-measurement#1410

![image](https://github.com/world-federation-of-advertisers/common-jvm/assets/85768771/e6ee6874-12db-459f-977a-c6e73636c80d)
