### PR TITLE
fix: Use subject hash for openssl macro test

### DIFF
--- a/build/openssl/generate_root_certificate_validator.sh
+++ b/build/openssl/generate_root_certificate_validator.sh
@@ -35,7 +35,7 @@ readonly CERT_PATH="${TESTDATA_DIR}/test_root.pem"
 readonly KEY_PATH="${TESTDATA_DIR}/test_root.key"
 readonly ORG='Some Organization'
 readonly COMMON_NAME='Some CA'
-readonly SUBJECT="subject=O = ${ORG}, CN = ${COMMON_NAME}"
+readonly SUBJECT_HASH='e65a7621'
 readonly HOSTNAME='ca.someorg.example.com'
 
 err() {
@@ -61,10 +61,10 @@ main() {
   fi
 
   # Check the certificate details
-  local subject
-  subject="$(openssl x509 -in "${cert_file}" -noout -subject)"
-  if [[ "${subject}" != "${SUBJECT}" ]]; then
-    err "Not true that ${subject} is equal to ${SUBJECT}"
+  local subject_hash
+  subject_hash="$(openssl x509 -in "${cert_file}" -noout -subject_hash)"
+  if [[ "${subject_hash}" != "${SUBJECT_HASH}" ]]; then
+    err "Not true that subject hash ${subject_hash} is equal to ${SUBJECT_HASH}"
     exit 1
   fi
 }

--- a/build/openssl/generate_user_certificate_validator.sh
+++ b/build/openssl/generate_user_certificate_validator.sh
@@ -37,7 +37,7 @@ readonly CERT_PATH="${TESTDATA_DIR}/test_user.pem"
 readonly KEY_PATH="${TESTDATA_DIR}/test_user.key"
 readonly ORG='Some Organization'
 readonly COMMON_NAME='Some Server'
-readonly SUBJECT="subject=O = ${ORG}, CN = ${COMMON_NAME}"
+readonly SUBJECT_HASH='bf3afa36'
 readonly HOSTNAME='server.someorg.example.com'
 
 err() {
@@ -67,10 +67,10 @@ main() {
   fi
 
   # Check the certificate details
-  local subject
-  subject="$(openssl x509 -in "${cert_file}" -noout -subject)"
-  if [[ "${subject}" != "${SUBJECT}" ]]; then
-    err "Not true that ${subject} is equal to ${SUBJECT}"
+  local subject_hash
+  subject_hash="$(openssl x509 -in "${cert_file}" -noout -subject_hash)"
+  if [[ "${subject_hash}" != "${SUBJECT_HASH}" ]]; then
+    err "Not true that subject hash ${subject_hash} is equal to ${SUBJECT_HASH}"
     exit 1
   fi
 }


### PR DESCRIPTION
The subject output appears to have changed in more recent OpenSSL versions, but the hash algorithm has been stable since OpenSSL 1.0.0.