### PR TITLE
fix!: Make Spanner AsyncDatabaseClient read/write transactions actually asynchronous

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/gcloud/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/common/BUILD.bazel
@@ -14,5 +14,6 @@ kt_jvm_library(
         "//imports/kotlin/com/google/type:date_kt_jvm_proto",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//imports/kotlin/kotlinx/coroutines/guava",
+        "//src/main/kotlin/org/wfanet/measurement/common/guava",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/AsyncDatabaseClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/AsyncDatabaseClient.kt
@@ -14,51 +14,58 @@
 
 package org.wfanet.measurement.gcloud.spanner
 
+import com.google.api.core.ApiFuture
+import com.google.api.core.SettableApiFuture
 import com.google.cloud.Timestamp
+import com.google.cloud.spanner.AbortedException
 import com.google.cloud.spanner.AsyncResultSet
-import com.google.cloud.spanner.AsyncRunner
+import com.google.cloud.spanner.AsyncTransactionManager
 import com.google.cloud.spanner.CommitResponse
 import com.google.cloud.spanner.DatabaseClient
 import com.google.cloud.spanner.DatabaseId
 import com.google.cloud.spanner.Key
 import com.google.cloud.spanner.KeySet
 import com.google.cloud.spanner.Mutation
+import com.google.cloud.spanner.Options
 import com.google.cloud.spanner.Options.QueryOption
 import com.google.cloud.spanner.Options.ReadOption
+import com.google.cloud.spanner.Options.UpdateOption
 import com.google.cloud.spanner.ReadContext
 import com.google.cloud.spanner.ReadOnlyTransaction
 import com.google.cloud.spanner.Spanner
-import com.google.cloud.spanner.SpannerException
 import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
 import com.google.cloud.spanner.TimestampBound
 import com.google.cloud.spanner.TransactionContext
+import com.google.common.util.concurrent.MoreExecutors
 import java.time.Duration
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executor
-import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.time.withTimeout
-import org.wfanet.measurement.gcloud.common.asApiFuture
 import org.wfanet.measurement.gcloud.common.await
 
-typealias TransactionWork<R> =
-  suspend CoroutineScope.(txn: AsyncDatabaseClient.TransactionContext) -> R
+typealias TransactionWork<R> = suspend (txn: AsyncDatabaseClient.TransactionContext) -> R
+
+private typealias TransactionStep = AsyncTransactionManager.AsyncTransactionStep<*, Any>
 
 /**
  * Non-blocking wrapper around [dbClient] using asynchronous Spanner Java API.
@@ -66,9 +73,8 @@ typealias TransactionWork<R> =
  * This class only exposes the methods used by this project and not the complete API.
  *
  * @param dbClient [DatabaseClient] to wrap
- * @param executor [Executor] for read-write transactions
  */
-class AsyncDatabaseClient(private val dbClient: DatabaseClient, private val executor: Executor) {
+class AsyncDatabaseClient(private val dbClient: DatabaseClient) {
   /** @see DatabaseClient.singleUse */
   fun singleUse(bound: TimestampBound = TimestampBound.strong()): ReadContext {
     return ReadContextImpl(dbClient.singleUse(bound))
@@ -87,8 +93,8 @@ class AsyncDatabaseClient(private val dbClient: DatabaseClient, private val exec
   }
 
   /** @see DatabaseClient.readWriteTransaction */
-  fun readWriteTransaction(): TransactionRunner {
-    return TransactionRunnerImpl(dbClient.runAsync())
+  fun readWriteTransaction(vararg options: Options.TransactionOption): TransactionRunner {
+    return TransactionRunnerImpl(TransactionManagerImpl(dbClient.transactionManagerAsync(*options)))
   }
 
   /** @see DatabaseClient.write */
@@ -164,15 +170,13 @@ class AsyncDatabaseClient(private val dbClient: DatabaseClient, private val exec
   }
 
   /** Async coroutine version of [com.google.cloud.spanner.TransactionRunner]. */
-  interface TransactionRunner {
+  interface TransactionRunner : AutoCloseable {
     /**
      * Executes a read/write transaction with retries as necessary.
      *
+     * This will close the [TransactionRunner].
+     *
      * @param doWork function that does work inside a transaction
-     *
-     * This acts as a coroutine builder. [doWork] has a [CoroutineScope] receiver to ensure that
-     * coroutine builders called from it run in the [CoroutineScope] defined by this function.
-     *
      * @see com.google.cloud.spanner.TransactionRunner.run
      */
     suspend fun <R> run(doWork: TransactionWork<R>): R
@@ -197,21 +201,7 @@ class AsyncDatabaseClient(private val dbClient: DatabaseClient, private val exec
     fun buffer(mutations: Iterable<Mutation>)
 
     /** @see com.google.cloud.spanner.TransactionContext.executeUpdate */
-    suspend fun executeUpdate(statement: Statement): Long
-  }
-
-  private inner class TransactionRunnerImpl(private val delegate: AsyncRunner) : TransactionRunner {
-    override suspend fun <R> run(doWork: TransactionWork<R>): R {
-      try {
-        return delegate.run(executor, doWork)
-      } catch (e: SpannerException) {
-        throw e.wrappedException ?: e
-      }
-    }
-
-    override suspend fun getCommitTimestamp(): Timestamp = delegate.commitTimestamp.await()
-
-    override suspend fun getCommitResponse(): CommitResponse = delegate.commitResponse.await()
+    suspend fun executeUpdate(statement: Statement, vararg options: UpdateOption): Long
   }
 
   companion object {
@@ -219,18 +209,18 @@ class AsyncDatabaseClient(private val dbClient: DatabaseClient, private val exec
   }
 }
 
-private class ReadContextImpl(private val readContext: ReadContext) :
-  AsyncDatabaseClient.ReadContext, AutoCloseable by readContext {
+private class ReadContextImpl(private val delegate: ReadContext) :
+  AsyncDatabaseClient.ReadContext, AutoCloseable by delegate {
 
   override fun read(
     table: String,
     keys: KeySet,
     columns: Iterable<String>,
     vararg options: ReadOption,
-  ): Flow<Struct> = flowFrom { readContext.readAsync(table, keys, columns, *options) }
+  ): Flow<Struct> = flowFrom { delegate.readAsync(table, keys, columns, *options) }
 
   override suspend fun readRow(table: String, key: Key, columns: Iterable<String>): Struct? {
-    return readContext.readRowAsync(table, key, columns).await()
+    return delegate.readRowAsync(table, key, columns).await()
   }
 
   override suspend fun readRowUsingIndex(
@@ -239,7 +229,7 @@ private class ReadContextImpl(private val readContext: ReadContext) :
     key: Key,
     columns: Iterable<String>,
   ): Struct? {
-    return readContext.readRowUsingIndexAsync(table, index, key, columns).await()
+    return delegate.readRowUsingIndexAsync(table, index, key, columns).await()
   }
 
   override suspend fun readRowUsingIndex(
@@ -256,12 +246,20 @@ private class ReadContextImpl(private val readContext: ReadContext) :
     index: String,
     keySet: KeySet,
     columns: Iterable<String>,
-  ): Flow<Struct> = flowFrom { readContext.readUsingIndexAsync(table, index, keySet, columns) }
+  ): Flow<Struct> = flowFrom { delegate.readUsingIndexAsync(table, index, keySet, columns) }
 
   override fun executeQuery(statement: Statement, vararg options: QueryOption): Flow<Struct> =
     flowFrom {
-      readContext.executeQueryAsync(statement, *options)
+      delegate.executeQueryAsync(statement, *options)
     }
+
+  private fun flowFrom(executeQuery: () -> AsyncResultSet): Flow<Struct> = callbackFlow {
+    // Defer executing the query until we're in the producer scope.
+    val resultSet: AsyncResultSet = executeQuery()
+
+    resultSet.setCallback(underlyingExecutor, ::readyCallback)
+    awaitClose { resultSet.close() }
+  }
 }
 
 private class ReadOnlyTransactionImpl(private val delegate: ReadOnlyTransaction) :
@@ -271,91 +269,242 @@ private class ReadOnlyTransactionImpl(private val delegate: ReadOnlyTransaction)
     get() = delegate.readTimestamp
 }
 
-private class TransactionContextImpl(private val txn: TransactionContext) :
-  AsyncDatabaseClient.TransactionContext, AsyncDatabaseClient.ReadContext by ReadContextImpl(txn) {
+/** Async coroutine wrapper around [AsyncTransactionManager]. */
+private class TransactionManagerImpl(private val delegate: AsyncTransactionManager) :
+  AutoCloseable by delegate {
 
-  override fun buffer(mutation: Mutation) = txn.buffer(mutation)
+  private lateinit var transactionFuture: AsyncTransactionManager.TransactionContextFuture
+  private var lastTransactionStep: TransactionStep? = null
 
-  override fun buffer(mutations: Iterable<Mutation>) = txn.buffer(mutations)
+  fun beginTransaction(): AsyncDatabaseClient.TransactionContext {
+    check(!::transactionFuture.isInitialized) { "Transaction already begun" }
+    transactionFuture = delegate.beginAsync()
+    return TransactionContextImpl(this)
+  }
 
-  override suspend fun executeUpdate(statement: Statement): Long {
-    return txn.executeUpdateAsync(statement).await()
+  suspend fun commit(): Timestamp {
+    val lastTransactionStep = lastTransactionStep
+    check(lastTransactionStep != null) { "Empty transaction" }
+
+    return lastTransactionStep.commitAsync().asConformingFuture().await()
+  }
+
+  fun resetForRetry() {
+    check(::transactionFuture.isInitialized) { "Transaction not yet begun" }
+    transactionFuture = delegate.resetForRetryAsync()
+    lastTransactionStep = null
+  }
+
+  suspend fun getCommitResponse(): CommitResponse = delegate.commitResponse.await()
+
+  private fun <T> runInTransaction(operation: (TransactionContext) -> ApiFuture<T>): ApiFuture<T> {
+    val transactionStep = lastTransactionStep
+    return if (transactionStep == null) {
+        transactionFuture.then({ txn, _ -> operation(txn) }, MoreExecutors.directExecutor())
+      } else {
+        transactionStep.then({ txn, _ -> operation(txn) }, MoreExecutors.directExecutor())
+      }
+      .also {
+        @Suppress("UNCHECKED_CAST") // Each step has different types.
+        lastTransactionStep = it as TransactionStep
+      }
+  }
+
+  private class TransactionContextImpl(private val manager: TransactionManagerImpl) :
+    AsyncDatabaseClient.TransactionContext, AutoCloseable by manager {
+
+    override fun buffer(mutation: Mutation) {
+      manager.runInTransaction { txn -> txn.bufferAsync(mutation) }
+    }
+
+    override fun buffer(mutations: Iterable<Mutation>) {
+      manager.runInTransaction { txn -> txn.bufferAsync(mutations) }
+    }
+
+    override suspend fun executeUpdate(statement: Statement, vararg options: UpdateOption): Long {
+      return manager.runInTransaction { txn -> txn.executeUpdateAsync(statement, *options) }.await()
+    }
+
+    override fun read(
+      table: String,
+      keys: KeySet,
+      columns: Iterable<String>,
+      vararg options: ReadOption,
+    ): Flow<Struct> = flowFrom { txn -> txn.readAsync(table, keys, columns, *options) }
+
+    override suspend fun readRow(table: String, key: Key, columns: Iterable<String>): Struct? {
+      return manager.runInTransaction { txn -> txn.readRowAsync(table, key, columns) }.await()
+    }
+
+    override suspend fun readRowUsingIndex(
+      table: String,
+      index: String,
+      key: Key,
+      columns: Iterable<String>,
+    ): Struct? {
+      return manager
+        .runInTransaction { txn -> txn.readRowUsingIndexAsync(table, index, key, columns) }
+        .await()
+    }
+
+    override suspend fun readRowUsingIndex(
+      table: String,
+      index: String,
+      key: Key,
+      vararg columns: String,
+    ): Struct? = readRowUsingIndex(table, index, key, columns.asIterable())
+
+    override suspend fun readUsingIndex(
+      table: String,
+      index: String,
+      keySet: KeySet,
+      columns: Iterable<String>,
+    ): Flow<Struct> = flowFrom { txn -> txn.readUsingIndexAsync(table, index, keySet, columns) }
+
+    override fun executeQuery(statement: Statement, vararg options: QueryOption): Flow<Struct> =
+      flowFrom { txn ->
+        txn.executeQueryAsync(statement, *options)
+      }
+
+    private fun flowFrom(read: (TransactionContext) -> AsyncResultSet): Flow<Struct> =
+      callbackFlow {
+        val future = SettableApiFuture.create<Unit>()
+        var resultSet: AsyncResultSet? = null
+
+        manager.runInTransaction { txn ->
+          resultSet = read(txn).also { it.setCallback(underlyingExecutor, ::readyCallback) }
+          future
+        }
+        awaitClose {
+          resultSet?.close()
+          future.set(Unit)
+        }
+      }
   }
 }
 
-@OptIn(ExperimentalStdlibApi::class) // For CoroutineDispatcher
-private fun flowFrom(executeQuery: () -> AsyncResultSet): Flow<Struct> = callbackFlow {
-  // Defer executing the query until we're in the producer scope.
-  val resultSet: AsyncResultSet = executeQuery()
+/**
+ * [AsyncDatabaseClient.TransactionRunner] implementation.
+ *
+ * This wraps [AsyncTransactionManager] rather than [com.google.cloud.spanner.AsyncRunner] as the
+ * latter makes blocking calls.
+ *
+ * TODO(googleapis/java-spanner#2698): Consider switching to AsyncRunner when fixed.
+ */
+private class TransactionRunnerImpl(private val manager: TransactionManagerImpl) :
+  AsyncDatabaseClient.TransactionRunner, AutoCloseable by manager {
 
-  val dispatcher = coroutineContext[CoroutineDispatcher] ?: Dispatchers.Default
-  resultSet.setCallback(dispatcher.asExecutor()) { cursor ->
-    try {
-      cursorReady(cursor)
-    } catch (t: Throwable) {
-      close(t)
-      resultSet.cancel()
-      AsyncResultSet.CallbackResponse.DONE
+  override suspend fun <R> run(doWork: TransactionWork<R>): R {
+    use {
+      val txn: AsyncDatabaseClient.TransactionContext = manager.beginTransaction()
+      while (true) {
+        coroutineContext.ensureActive()
+        val result: R? =
+          try {
+            doWork(txn)
+          } catch (e: AbortedException) {
+            // `AsyncDatabaseClient.TransactionContext` methods suspend until getting the
+            // intermediate results, so exceptions bubble up through them as well as through
+            // `commit`. Suppress this exception here so that `commit` handling is triggered.
+            null
+          }
+        try {
+          manager.commit()
+          return result!! // Result cannot be null if commit is successful.
+        } catch (e: AbortedException) {
+          delay(e.retryDelayInMillis)
+          manager.resetForRetry()
+        }
+      }
     }
   }
-  awaitClose { resultSet.close() }
+
+  override suspend fun getCommitTimestamp(): Timestamp = getCommitResponse().commitTimestamp
+
+  override suspend fun getCommitResponse(): CommitResponse = manager.getCommitResponse()
 }
 
-private fun ProducerScope<Struct>.cursorReady(
+/**
+ * Adapter for [AsyncTransactionManager.CommitTimestampFuture] which conforms to the
+ * [java.util.concurrent.Future.get] contract.
+ *
+ * TODO(googleapis/java-spanner#3414): Remove when fixed.
+ */
+private class ConformingFutureAdapter(
+  private val delegate: AsyncTransactionManager.CommitTimestampFuture
+) : ApiFuture<Timestamp> by delegate {
+  override fun get(): Timestamp {
+    return try {
+      delegate.get()
+    } catch (e: AbortedException) {
+      throw ExecutionException(e)
+    }
+  }
+
+  override fun get(timeout: Long, unit: TimeUnit): Timestamp {
+    return try {
+      delegate.get(timeout, unit)
+    } catch (e: AbortedException) {
+      throw ExecutionException(e)
+    }
+  }
+}
+
+/**
+ * Returns this [AsyncTransactionManager.CommitTimestampFuture] as an [ApiFuture] which conforms to
+ * the [java.util.concurrent.Future.get] contract.
+ *
+ * TODO(googleapis/java-spanner#3414): Remove when fixed.
+ */
+private fun AsyncTransactionManager.CommitTimestampFuture.asConformingFuture():
+  ApiFuture<Timestamp> = ConformingFutureAdapter(this)
+
+/** Coroutine [AsyncResultSet.ReadyCallback]. */
+private fun ProducerScope<Struct>.readyCallback(
   cursor: AsyncResultSet
 ): AsyncResultSet.CallbackResponse {
-  while (true) {
-    when (checkNotNull(cursor.tryNext())) {
-      AsyncResultSet.CursorState.OK -> {
-        val currentRow = cursor.currentRowAsStruct
-        if (trySend(currentRow).isSuccess) {
-          continue
-        }
-        launch(CoroutineName("AsyncResultSet cursorReady resume")) {
-          try {
-            send(currentRow)
-            cursor.resume()
-          } catch (t: Throwable) {
-            this@cursorReady.cancel(CancellationException("Error resuming AsyncResultSet", t))
-            cursor.cancel()
+  try {
+    while (true) {
+      when (checkNotNull(cursor.tryNext())) {
+        AsyncResultSet.CursorState.OK -> {
+          val currentRow = cursor.currentRowAsStruct
+          if (trySend(currentRow).isSuccess) {
+            continue
           }
+          launch(CoroutineName("AsyncResultSet cursorReady resume")) {
+            try {
+              send(currentRow)
+              cursor.resume()
+            } catch (t: Throwable) {
+              cancel(CancellationException("Error resuming AsyncResultSet", t))
+              cursor.cancel()
+            }
+          }
+          return AsyncResultSet.CallbackResponse.PAUSE
         }
-        return AsyncResultSet.CallbackResponse.PAUSE
-      }
-      AsyncResultSet.CursorState.NOT_READY -> return AsyncResultSet.CallbackResponse.CONTINUE
-      AsyncResultSet.CursorState.DONE -> {
-        close()
-        return AsyncResultSet.CallbackResponse.DONE
+        AsyncResultSet.CursorState.NOT_READY -> return AsyncResultSet.CallbackResponse.CONTINUE
+        AsyncResultSet.CursorState.DONE -> {
+          close()
+          return AsyncResultSet.CallbackResponse.DONE
+        }
       }
     }
+  } catch (t: Throwable) {
+    close(t)
+    cursor.cancel()
+    return AsyncResultSet.CallbackResponse.DONE
   }
 }
 
-private suspend fun <T> AsyncRunner.run(executor: Executor, doWork: TransactionWork<T>): T {
-  // The Spanner client library may call the async callback multiple times as it performs retries on
-  // certain exceptions. Therefore, we use supervisorScope to prevent these exceptions from
-  // cancelling the parent job.
-  return supervisorScope {
-    val asyncWork =
-      AsyncRunner.AsyncWork { txn ->
-        async {
-            // Create a separate coroutine scope so that we have normal (non-supervisor) structured
-            // concurrency semantics for the actual work.
-            coroutineScope { doWork(txn.asAsyncTransaction()) }
-          }
-          .asApiFuture()
-      }
-
-    // Wait inside the supervisor scope to ensure any callback futures are created before the scope
-    // completes, and also propagate cancellation to child coroutines.
-    runAsync(asyncWork, executor).await()
+private val CoroutineScope.underlyingExecutor: Executor
+  get() {
+    val dispatcher: ContinuationInterceptor? = coroutineContext[ContinuationInterceptor]
+    // Dispatchers.Unconfined throws when used as an executor.
+    if (dispatcher is CoroutineDispatcher && dispatcher !== Dispatchers.Unconfined) {
+      return dispatcher.asExecutor()
+    }
+    return Dispatchers.Default.asExecutor()
   }
-}
 
-private fun TransactionContext.asAsyncTransaction(): AsyncDatabaseClient.TransactionContext =
-  TransactionContextImpl(this)
-
-fun Spanner.getAsyncDatabaseClient(
-  databaseId: DatabaseId,
-  executor: Executor = Executors.newSingleThreadExecutor(),
-) = AsyncDatabaseClient(getDatabaseClient(databaseId), executor)
+fun Spanner.getAsyncDatabaseClient(databaseId: DatabaseId) =
+  AsyncDatabaseClient(getDatabaseClient(databaseId))

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/SpannerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/spanner/SpannerFlags.kt
@@ -22,7 +22,7 @@ class SpannerFlags {
   @CommandLine.Option(
     names = ["--spanner-project"],
     description = ["Name of the Spanner project."],
-    required = true
+    required = true,
   )
   lateinit var projectName: String
     private set
@@ -30,7 +30,7 @@ class SpannerFlags {
   @CommandLine.Option(
     names = ["--spanner-instance"],
     description = ["Name of the Spanner instance."],
-    required = true
+    required = true,
   )
   lateinit var instanceName: String
     private set
@@ -38,7 +38,7 @@ class SpannerFlags {
   @CommandLine.Option(
     names = ["--spanner-database"],
     description = ["Name of the Spanner database."],
-    required = true
+    required = true,
   )
   lateinit var databaseName: String
     private set
@@ -46,7 +46,7 @@ class SpannerFlags {
   @CommandLine.Option(
     names = ["--spanner-ready-timeout"],
     description = ["How long to wait for Spanner to be ready."],
-    defaultValue = "10s"
+    defaultValue = "10s",
   )
   lateinit var readyTimeout: Duration
     private set
@@ -54,29 +54,9 @@ class SpannerFlags {
   @CommandLine.Option(
     names = ["--spanner-emulator-host"],
     description = ["Host name and port of the spanner emulator."],
-    required = false
+    required = false,
   )
   var emulatorHost: String? = null
-    private set
-
-  @CommandLine.Option(
-    names = ["--spanner-transaction-timeout"],
-    description = ["Timeout duration for read-write transactions"],
-    defaultValue = "1m"
-  )
-  lateinit var transactionTimeout: Duration
-    private set
-
-  @CommandLine.Option(
-    names = ["--spanner-transaction-max-threads"],
-    description =
-      [
-        "Maximum number of threads to use for read-write transactions.",
-        "Defaults to number of processors * 2.",
-        "Ignored when --spanner-emulator-host is specified."
-      ],
-  )
-  var maxTransactionThreads: Int = DEFAULT_THREAD_POOL_SIZE
     private set
 
   val jdbcConnectionString: String
@@ -88,8 +68,4 @@ class SpannerFlags {
         "jdbc:cloudspanner://$emulatorHost/$databasePath;usePlainText=true;autoConfigEmulator=true"
       }
     }
-
-  companion object {
-    private val DEFAULT_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2
-  }
 }


### PR DESCRIPTION
The `AsyncRunner` implementation apparently runs blocking code in a separate thread. This changes `AsyncDatabaseClient` to wrap `AsyncTransactionManager` instead.

BREAKING CHANGE: `AsyncDatabaseClient` no longer takes an `Executor` for read/write transactions
BREAKING CHANGE: Unused flags for building the read/write transaction `Executor` have been removed from `SpannerFlags`
BREAKING CHANGE: `TransactionWork` no longer has a `CoroutineScope` receiver.