### PR TITLE
fix!: Verify audience claim matches client ID for OpenID provider

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/OpenIdConnectAuthenticationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/OpenIdConnectAuthenticationTest.kt
@@ -38,11 +38,11 @@ class OpenIdConnectAuthenticationTest {
   fun `verifyAndDecodeBearerToken returns VerifiedToken`() {
     val issuer = "example.com"
     val subject = "user1@example.com"
-    val audience = "foobar"
+    val clientId = "foobar"
     val scopes = setOf("foo.bar", "foo.baz")
-    val openIdProvider = OpenIdProvider(issuer)
-    val credentials = openIdProvider.generateCredentials(audience, subject, scopes)
-    val auth = OpenIdConnectAuthentication(audience, listOf(openIdProvider.providerConfig))
+    val openIdProvider = OpenIdProvider(issuer, clientId)
+    val credentials = openIdProvider.generateCredentials(subject, scopes)
+    val auth = OpenIdConnectAuthentication(listOf(openIdProvider.providerConfig))
 
     val token = auth.verifyAndDecodeBearerToken(extractHeaders(credentials))
 
@@ -53,17 +53,16 @@ class OpenIdConnectAuthenticationTest {
   fun `verifyAndDecodeBearerToken throws UNAUTHENTICATED when token is expired`() {
     val issuer = "example.com"
     val subject = "user1@example.com"
-    val audience = "foobar"
+    val clientId = "foobar"
     val scopes = setOf("foo.bar", "foo.baz")
-    val openIdProvider = OpenIdProvider(issuer)
+    val openIdProvider = OpenIdProvider(issuer, clientId)
     val credentials =
       openIdProvider.generateCredentials(
-        audience,
         subject,
         scopes,
         Instant.now().minus(Duration.ofMinutes(5)),
       )
-    val auth = OpenIdConnectAuthentication(audience, listOf(openIdProvider.providerConfig))
+    val auth = OpenIdConnectAuthentication(listOf(openIdProvider.providerConfig))
 
     val exception =
       assertFailsWith<StatusException> {
@@ -78,11 +77,14 @@ class OpenIdConnectAuthenticationTest {
   fun `verifyAndDecodeBearerToken throws UNAUTHENTICATED when audience does not match`() {
     val issuer = "example.com"
     val subject = "user1@example.com"
-    val audience = "foobar"
+    val clientId = "foobar"
     val scopes = setOf("foo.bar", "foo.baz")
-    val openIdProvider = OpenIdProvider(issuer)
-    val credentials = openIdProvider.generateCredentials("bad-audience", subject, scopes)
-    val auth = OpenIdConnectAuthentication(audience, listOf(openIdProvider.providerConfig))
+    val openIdProvider = OpenIdProvider(issuer, clientId)
+    val credentials = openIdProvider.generateCredentials(subject, scopes)
+    val auth =
+      OpenIdConnectAuthentication(
+        listOf(openIdProvider.providerConfig.copy(clientId = "bad-client-id"))
+      )
 
     val exception =
       assertFailsWith<StatusException> {
@@ -97,11 +99,11 @@ class OpenIdConnectAuthenticationTest {
   fun `verifyAndDecodeBearerToken throws UNAUTHENTICATED when provider not found for issuer`() {
     val issuer = "example.com"
     val subject = "user1@example.com"
-    val audience = "foobar"
+    val clientId = "foobar"
     val scopes = setOf("foo.bar", "foo.baz")
-    val openIdProvider = OpenIdProvider(issuer)
-    val credentials = openIdProvider.generateCredentials(audience, subject, scopes)
-    val auth = OpenIdConnectAuthentication(audience, emptyList())
+    val openIdProvider = OpenIdProvider(issuer, clientId)
+    val credentials = openIdProvider.generateCredentials(subject, scopes)
+    val auth = OpenIdConnectAuthentication(emptyList())
 
     val exception =
       assertFailsWith<StatusException> {
@@ -114,9 +116,8 @@ class OpenIdConnectAuthenticationTest {
 
   @Test
   fun `verifyAndDecodeBearerToken throws UNAUTHENTICATED when token is not a valid JWT`() {
-    val audience = "foobar"
     val credentials = BearerTokenCallCredentials("foo", false)
-    val auth = OpenIdConnectAuthentication(audience, emptyList())
+    val auth = OpenIdConnectAuthentication(emptyList())
 
     val exception =
       assertFailsWith<StatusException> {
@@ -129,8 +130,7 @@ class OpenIdConnectAuthenticationTest {
 
   @Test
   fun `verifyAndDecodeBearerToken throws UNAUTHENTICATED when header not found`() {
-    val audience = "foobar"
-    val auth = OpenIdConnectAuthentication(audience, emptyList())
+    val auth = OpenIdConnectAuthentication(emptyList())
 
     val exception = assertFailsWith<StatusException> { auth.verifyAndDecodeBearerToken(Metadata()) }
 


### PR DESCRIPTION
This addresses a bug in #288 

The client ID is generated by the OpenID provider on registration, so the OpenID provider configuration needs to include the client ID.