### PR TITLE
Revert "fix!: Verify audience claim matches client ID for OpenID provider"

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/OpenIdProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/OpenIdProvider.kt
@@ -29,35 +29,35 @@ import org.wfanet.measurement.common.grpc.BearerTokenCallCredentials
 import org.wfanet.measurement.common.grpc.OpenIdConnectAuthentication
 
 /** An ephemeral OpenID provider for testing. */
-class OpenIdProvider(issuer: String, clientId: String) {
+class OpenIdProvider(private val issuer: String) {
   private val jwkSetHandle = KeysetHandle.generateNew(KEY_TEMPLATE)
 
-  val providerConfig =
-    OpenIdConnectAuthentication.OpenIdProviderConfig(
-      issuer,
-      JwkSetConverter.fromPublicKeysetHandle(jwkSetHandle.publicKeysetHandle),
-      clientId,
-    )
+  val providerConfig: OpenIdConnectAuthentication.OpenIdProviderConfig by lazy {
+    val jwks = JwkSetConverter.fromPublicKeysetHandle(jwkSetHandle.publicKeysetHandle)
+    OpenIdConnectAuthentication.OpenIdProviderConfig(issuer, jwks)
+  }
 
   fun generateCredentials(
+    audience: String,
     subject: String,
     scopes: Set<String>,
     expiration: Instant = Instant.now().plus(Duration.ofMinutes(5)),
   ): BearerTokenCallCredentials {
-    val token = generateSignedToken(subject, scopes, expiration)
+    val token = generateSignedToken(audience, subject, scopes, expiration)
     return BearerTokenCallCredentials(token, false)
   }
 
   /** Generates a signed and encoded JWT using the specified parameters. */
   private fun generateSignedToken(
+    audience: String,
     subject: String,
     scopes: Set<String>,
     expiration: Instant,
   ): String {
     val rawJwt =
       RawJwt.newBuilder()
-        .setAudience(providerConfig.clientId)
-        .setIssuer(providerConfig.issuer)
+        .setAudience(audience)
+        .setIssuer(issuer)
         .setSubject(subject)
         .addStringClaim("scope", scopes.joinToString(" "))
         .setExpiration(expiration)


### PR DESCRIPTION
Reverts world-federation-of-advertisers/common-jvm#290

The `aud` (audience) claim is only required to match the client ID for OpenID Connect (OIDC) ID Tokens. For authentication, the expectation is to use RFC 9068 Access Tokens where the audience is application-specific.