### PR TITLE
feat!: Allow private key to be specified to OpenIdProvider

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/OpenIdProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/OpenIdProvider.kt
@@ -23,15 +23,19 @@ import com.google.crypto.tink.jwt.JwkSetConverter
 import com.google.crypto.tink.jwt.JwtPublicKeySign
 import com.google.crypto.tink.jwt.JwtSignatureConfig
 import com.google.crypto.tink.jwt.RawJwt
+import java.time.Clock
 import java.time.Duration
-import java.time.Instant
+import java.util.UUID
 import org.wfanet.measurement.common.grpc.BearerTokenCallCredentials
 import org.wfanet.measurement.common.grpc.OpenIdConnectAuthentication
 
-/** An ephemeral OpenID provider for testing. */
-class OpenIdProvider(private val issuer: String) {
-  private val jwkSetHandle = KeysetHandle.generateNew(KEY_TEMPLATE)
-
+/** An OpenID provider for testing. */
+class OpenIdProvider(
+  private val issuer: String,
+  private val jwkSetHandle: KeysetHandle = KeysetHandle.generateNew(KEY_TEMPLATE),
+  private val clock: Clock = Clock.systemUTC(),
+  private val generateUuid: () -> UUID = UUID::randomUUID,
+) {
   val providerConfig: OpenIdConnectAuthentication.OpenIdProviderConfig by lazy {
     val jwks = JwkSetConverter.fromPublicKeysetHandle(jwkSetHandle.publicKeysetHandle)
     OpenIdConnectAuthentication.OpenIdProviderConfig(issuer, jwks)
@@ -41,9 +45,10 @@ class OpenIdProvider(private val issuer: String) {
     audience: String,
     subject: String,
     scopes: Set<String>,
-    expiration: Instant = Instant.now().plus(Duration.ofMinutes(5)),
+    ttl: Duration = Duration.ofMinutes(5),
+    clientId: String = DEFAULT_CLIENT_ID,
   ): BearerTokenCallCredentials {
-    val token = generateSignedToken(audience, subject, scopes, expiration)
+    val token = generateSignedToken(audience, subject, scopes, clientId, ttl)
     return BearerTokenCallCredentials(token, false)
   }
 
@@ -52,15 +57,21 @@ class OpenIdProvider(private val issuer: String) {
     audience: String,
     subject: String,
     scopes: Set<String>,
-    expiration: Instant,
+    clientId: String,
+    ttl: Duration,
   ): String {
+    val jwtId = generateUuid()
+    val issuedAt = clock.instant()
     val rawJwt =
       RawJwt.newBuilder()
+        .setJwtId(jwtId.toString())
         .setAudience(audience)
         .setIssuer(issuer)
         .setSubject(subject)
+        .setIssuedAt(issuedAt)
+        .setExpiration(issuedAt.plus(ttl))
+        .addStringClaim("client_id", clientId)
         .addStringClaim("scope", scopes.joinToString(" "))
-        .setExpiration(expiration)
         .build()
     val signer = jwkSetHandle.getPrimitive(JwtPublicKeySign::class.java)
     return signer.signAndEncode(rawJwt)
@@ -71,6 +82,7 @@ class OpenIdProvider(private val issuer: String) {
       JwtSignatureConfig.register()
     }
 
+    const val DEFAULT_CLIENT_ID = "testing-client"
     private val KEY_TEMPLATE: KeyTemplate = KeyTemplates.get("JWT_ES256")
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/OpenIdConnectAuthenticationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/OpenIdConnectAuthenticationTest.kt
@@ -22,7 +22,6 @@ import io.grpc.Metadata
 import io.grpc.Status
 import io.grpc.StatusException
 import java.time.Duration
-import java.time.Instant
 import java.util.concurrent.Executor
 import kotlin.test.assertFailsWith
 import org.junit.Test
@@ -57,12 +56,7 @@ class OpenIdConnectAuthenticationTest {
     val scopes = setOf("foo.bar", "foo.baz")
     val openIdProvider = OpenIdProvider(issuer)
     val credentials =
-      openIdProvider.generateCredentials(
-        audience,
-        subject,
-        scopes,
-        Instant.now().minus(Duration.ofMinutes(5)),
-      )
+      openIdProvider.generateCredentials(audience, subject, scopes, ttl = Duration.ofMinutes(-1))
     val auth = OpenIdConnectAuthentication(audience, listOf(openIdProvider.providerConfig))
 
     val exception =


### PR DESCRIPTION
This allows OpenIdProvider to be used for integration tests which need a stable key.

This change also ensures that generated tokens include all required fields specified in RFC 9068.

BREAKING CHANGE: generateCredentials now takes a TTL Duration instead of an expiration Instant.