### PR TITLE
fix: Make client auth optional when `--require-client-auth` is false

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
@@ -226,7 +226,7 @@ private constructor(
       return fromParameters(
         flags.debugVerboseGrpcLogging,
         flags.tlsFlags.signingCerts,
-        if (flags.clientAuthRequired) ClientAuth.REQUIRE else ClientAuth.NONE,
+        if (flags.clientAuthRequired) ClientAuth.REQUIRE else ClientAuth.OPTIONAL,
         nameForLogging,
         services,
         flags.port,


### PR DESCRIPTION
Client auth was being turned off entirely instead.