### PR TITLE
fix: Include error code in JWT access token validation messages

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/OAuthTokenAuthenticationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/OAuthTokenAuthenticationTest.kt
@@ -66,6 +66,7 @@ class OAuthTokenAuthenticationTest {
 
     assertThat(exception.status.code).isEqualTo(Status.Code.UNAUTHENTICATED)
     assertThat(exception).hasMessageThat().ignoringCase().contains("expired")
+    assertThat(exception).hasMessageThat().contains("invalid_token")
   }
 
   @Test
@@ -85,6 +86,7 @@ class OAuthTokenAuthenticationTest {
 
     assertThat(exception.status.code).isEqualTo(Status.Code.UNAUTHENTICATED)
     assertThat(exception).hasMessageThat().ignoringCase().contains("audience")
+    assertThat(exception).hasMessageThat().contains("invalid_token")
   }
 
   @Test
@@ -104,6 +106,7 @@ class OAuthTokenAuthenticationTest {
 
     assertThat(exception.status.code).isEqualTo(Status.Code.UNAUTHENTICATED)
     assertThat(exception).hasMessageThat().ignoringCase().contains("issuer")
+    assertThat(exception).hasMessageThat().contains("invalid_token")
   }
 
   @Test
@@ -119,6 +122,7 @@ class OAuthTokenAuthenticationTest {
 
     assertThat(exception.status.code).isEqualTo(Status.Code.UNAUTHENTICATED)
     assertThat(exception).hasMessageThat().contains("JWT")
+    assertThat(exception).hasMessageThat().contains("invalid_token")
   }
 
   @Test


### PR DESCRIPTION
This is mandated by Section 4 of RFC 9068.