### PR TITLE
feat: Create Sharded Storage

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -34,3 +34,13 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/storage:store",
     ],
 )
+
+kt_jvm_library(
+    name = "sharded_storage_client",
+    srcs = ["ShardedStorageClient.kt"],
+    deps = [
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/storage:store",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -39,6 +39,7 @@ kt_jvm_library(
     name = "sharded_storage_client",
     srcs = ["ShardedStorageClient.kt"],
     deps = [
+        ":mesos_recordio_storage_client",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/kotlin/org/wfanet/measurement/storage:store",

--- a/src/main/kotlin/org/wfanet/measurement/storage/ShardedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ShardedStorageClient.kt
@@ -1,14 +1,14 @@
 package org.wfanet.measurement.storage
 
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.flattenMerge
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.reduce
 import kotlinx.coroutines.runBlocking
-import org.wfanet.measurement.common.base64UrlDecode
 
 class ShardedStorageClient(private val underlyingStorageClient: StorageClient): StorageClient {
 
@@ -20,25 +20,31 @@ class ShardedStorageClient(private val underlyingStorageClient: StorageClient): 
     val chunks = mutableListOf<Flow<ByteString>>()
     var currentChunk = mutableListOf<ByteString>()
 
-    // Shard current Flow<ByteString> into smaller Flow<ByteString> elements of size chunkSize
+    // Shard current Flow<ByteString> into smaller Flow<ByteString> chunks of size chunkSize
     content.collect { byteString ->
-      currentChunk.add(byteString)
+      val dataSize: String = byteString.size().toString()
+      val separatedChunk: String = dataSize + "\n" + byteString.toStringUtf8()
+      currentChunk.add(separatedChunk.toByteStringUtf8())
       if (currentChunk.size == chunkSize) {
         chunks.add(currentChunk.asFlow())
-        currentChunk = mutableListOf()
+        currentChunk = mutableListOf<ByteString>()
       }
     }
+    // Add any remaining elements as the last chunk
+    if (currentChunk.isNotEmpty()) {
+      chunks.add(currentChunk.asFlow())
+    }
 
-    // Write all smaller Flow<ByteString> shards to storage using the same blob key concatinated
+    // Write all smaller Flow<ByteString> chunks to storage using the same blob key concatinated
     // with the indexed entry of each shard with the pattern "-x-of-totalNumberOfChunks"
     chunks.mapIndexed { index, it ->
-      writeBlob("$blobKey-$index-of-${chunks.size}", it)
+      writeBlob("$blobKey-${index+1}-of-${chunks.size}", it)
     }
 
     // Write a string to storage that signifies the size of the sharded content and return Blob with this
     // metadata
-    val shardData = "$blobKey-*-of-${chunks.size}"
-    return writeBlob(blobKey, shardData.base64UrlDecode())
+    val shardData = listOf("$blobKey-*-of-${chunks.size}".toByteStringUtf8())
+    return writeBlob(blobKey, shardData.asFlow())
   }
   override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
     return underlyingStorageClient.writeBlob(blobKey, content)
@@ -52,6 +58,7 @@ class ShardedStorageClient(private val underlyingStorageClient: StorageClient): 
       val numShardsData= runBlocking {
         metadata.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
       }
+
       // Get total number of shards from blob with pattern xxxxxxxx-*-of-N where N is total number of shards
       val numShards = numShardsData.split("-of-").last().toInt()
 
@@ -61,7 +68,7 @@ class ShardedStorageClient(private val underlyingStorageClient: StorageClient): 
         filePaths.map {
           async {
             try {
-              storageClient.getBlob(it)!!.read()
+              storageClient.getBlob(it)!!
             } catch (e: Exception) {
               throw Exception("Error retrieving blob at path: $it:", e)
             }
@@ -70,7 +77,51 @@ class ShardedStorageClient(private val underlyingStorageClient: StorageClient): 
       }
 
       // 3. Return a merged Flow<ByteString>
-      return  shardedData.asFlow().flattenMerge()
+      return flow {
+        shardedData.map {
+          val recordSizeBuffer = StringBuilder()
+          var currentRecordSize = -1
+          var recordBuffer = ByteString.newOutput()
+
+          it.read().collect { chunk ->
+            var position = 0
+            val chunkString = chunk.toStringUtf8()
+
+            while (position < chunkString.length) {
+              if (currentRecordSize == -1) {
+
+                val newlineIndex = chunkString.indexOf("\n", position)
+                if (newlineIndex != -1) {
+                  recordSizeBuffer.append(chunkString.substring(position, newlineIndex))
+                  currentRecordSize = recordSizeBuffer.toString().toInt()
+                  recordSizeBuffer.clear()
+                  recordBuffer = ByteString.newOutput(currentRecordSize)
+                  position = newlineIndex + 1
+                } else {
+                  recordSizeBuffer.append(chunkString.substring(position))
+                  break
+                }
+              }
+              if (currentRecordSize > 0) {
+                val remainingBytes = chunkString.length - position
+                val bytesToRead = minOf(remainingBytes, currentRecordSize - recordBuffer.size())
+
+                if (bytesToRead > 0) {
+                  recordBuffer.write(
+                    chunkString.substring(position, position + bytesToRead).toByteArray(Charsets.UTF_8)
+                  )
+                  position += bytesToRead
+                }
+                if (recordBuffer.size() == currentRecordSize) {
+                  emit(recordBuffer.toByteString())
+                  currentRecordSize = -1
+                  recordBuffer.reset()
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
     override suspend fun delete() {

--- a/src/main/kotlin/org/wfanet/measurement/storage/ShardedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ShardedStorageClient.kt
@@ -1,0 +1,80 @@
+package org.wfanet.measurement.storage
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flattenMerge
+import kotlinx.coroutines.flow.reduce
+import kotlinx.coroutines.runBlocking
+import org.wfanet.measurement.common.base64UrlDecode
+
+class ShardedStorageClient(private val underlyingStorageClient: StorageClient): StorageClient {
+
+  override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
+    return Blob(blobKey, underlyingStorageClient, underlyingStorageClient.getBlob(blobKey)!!.size)
+  }
+
+  suspend fun writeBlob(blobKey: String, content: Flow<ByteString>, chunkSize: Int): StorageClient.Blob {
+    val chunks = mutableListOf<Flow<ByteString>>()
+    var currentChunk = mutableListOf<ByteString>()
+
+    // Shard current Flow<ByteString> into smaller Flow<ByteString> elements of size chunkSize
+    content.collect { byteString ->
+      currentChunk.add(byteString)
+      if (currentChunk.size == chunkSize) {
+        chunks.add(currentChunk.asFlow())
+        currentChunk = mutableListOf()
+      }
+    }
+
+    // Write all smaller Flow<ByteString> shards to storage using the same blob key concatinated
+    // with the indexed entry of each shard with the pattern "-x-of-totalNumberOfChunks"
+    chunks.mapIndexed { index, it ->
+      writeBlob("$blobKey-$index-of-${chunks.size}", it)
+    }
+
+    // Write a string to storage that signifies the size of the sharded content and return Blob with this
+    // metadata
+    val shardData = "$blobKey-*-of-${chunks.size}"
+    return writeBlob(blobKey, shardData.base64UrlDecode())
+  }
+  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+    return underlyingStorageClient.writeBlob(blobKey, content)
+  }
+  private inner class Blob(private val blobKey: String, override val storageClient: StorageClient, override val size: Long): StorageClient.Blob {
+    override fun read(): Flow<ByteString> {
+      // 1. Read original file to discover number of sharded files. Will be a string in the format "sharded-impressions-*-of-N"
+      val metadata  = runBlocking {
+        underlyingStorageClient.getBlob(blobKey)!! // /{prefix}/ds/{ds}/event-group-id/{event-group-id}/sharded-impressions
+      }
+      val numShardsData= runBlocking {
+        metadata.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
+      }
+      // Get total number of shards from blob with pattern xxxxxxxx-*-of-N where N is total number of shards
+      val numShards = numShardsData.split("-of-").last().toInt()
+
+      // 2. Read in different files in parallel from underlying storage client
+      val filePaths = (1..numShards).map { "$blobKey-$it-of-$numShards" }
+      val shardedData = runBlocking {
+        filePaths.map {
+          async {
+            try {
+              storageClient.getBlob(it)!!.read()
+            } catch (e: Exception) {
+              throw Exception("Error retrieving blob at path: $it:", e)
+            }
+          }
+        }.awaitAll()
+      }
+
+      // 3. Return a merged Flow<ByteString>
+      return  shardedData.asFlow().flattenMerge()
+    }
+
+    override suspend fun delete() {
+      storageClient.getBlob(blobKey)?.delete()
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -10,3 +10,14 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "ShardedStorageClientTest",
+    srcs = ["ShardedStorageClientTest.kt"],
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/org/junit",
+        "//src/main/kotlin/org/wfanet/measurement/storage:sharded_storage_client",
+        "//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -17,6 +17,7 @@ kt_jvm_test(
     deps = [
         "//imports/java/com/google/common/truth",
         "//imports/java/org/junit",
+        "//src/main/kotlin/org/wfanet/measurement/storage:mesos_recordio_storage_client",
         "//src/main/kotlin/org/wfanet/measurement/storage:sharded_storage_client",
         "//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/storage/ShardedStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ShardedStorageClientTest.kt
@@ -1,0 +1,41 @@
+package org.wfanet.measurement.storage
+
+import com.google.common.truth.Truth
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.reduce
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+
+class ShardedStorageClientTest {
+  private lateinit var wrappedStorageClient: StorageClient
+  private lateinit var shardedtorageClient: ShardedStorageClient
+
+  @Before
+  fun initStorageClient() {
+    wrappedStorageClient = InMemoryStorageClient()
+    shardedtorageClient = ShardedStorageClient(wrappedStorageClient)
+  }
+
+  @Test
+  fun `test writing and reading sharded record`() = runBlocking {
+    val testData = listOf("impression1", "impression2", "impression3", "impression4")
+    val blobKey = "/labelled-impressions/ds/2025-02-14/event-group-id/12345/sharded-impressions"
+
+    shardedtorageClient.writeBlob(
+      blobKey,
+      testData.map { it.toByteStringUtf8() }.asFlow(),
+      3
+    )
+    val blob = shardedtorageClient.getBlob(blobKey)
+    requireNotNull(blob) { "Blob should exist" }
+    val records = blob.read().toList().map { it.toStringUtf8().toString() }.toString()
+    Truth.assertThat(testData.toString()).isEqualTo(records)
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/storage/ShardedStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ShardedStorageClientTest.kt
@@ -2,12 +2,8 @@ package org.wfanet.measurement.storage
 
 import com.google.common.truth.Truth
 import com.google.protobuf.ByteString
-import com.google.protobuf.kotlin.toByteStringUtf8
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.reduce
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -76,6 +72,5 @@ class ShardedStorageClientTest {
     results.forEachIndexed { index, result ->
       Truth.assertThat(testData[index]).isEqualTo(result.toStringUtf8())
     }
-
   }
 }


### PR DESCRIPTION
Create sharded storage that will split data into chunks, and store chunks in shards within storage. 

When data is written, this client will:
1. Split the data into chunks
2. Write chunked data into shards in storage with the naming pattern: {blobKey}-x-of-N, where x is the shard index and N is the total number of shards
3. Write metadata to storage at the location of the blobKey. The metadata will have the pattern: {blobKey}-*-of-N, where N is the total number of shards

When data is read, the client will:
1. Read the metadata at location blobKey with the pattern: {blobKey}-*-of-N, where N is the total number of shards
2. Take N from the metadata and read all the shards in storage from 1 to n. Each shard will be stored at location {blobKey}-x-of-N,  where x is the shard index and N is the total number of shards
3. Merge the shards and return data