### PR TITLE
fix mesos storage client

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -32,10 +32,7 @@ import kotlinx.coroutines.flow.flow
  */
 // TODO(@marcopremier): Refactor into MesosRecordIoStore<T : Message> to handle proto message
 // serialization internally and make current StorageClient implementation private.
-class MesosRecordIoStorageClient(
-  private val storageClient: StorageClient,
-  private val recordDelimiter: ByteString = "\n".toByteStringUtf8(),
-) : StorageClient {
+class MesosRecordIoStorageClient(private val storageClient: StorageClient) : StorageClient {
 
   /**
    * Writes RecordIO rows to storage using the RecordIO format.
@@ -59,7 +56,7 @@ class MesosRecordIoStorageClient(
       content.collect { recordData: ByteString ->
         val recordSize = recordData.size().toString().toByteStringUtf8()
         recordsWritten++
-        emit(recordSize.concat(recordDelimiter).concat(recordData))
+        emit(recordSize.concat(RECORD_DELIMITER).concat(recordData))
       }
     }
 
@@ -125,7 +122,7 @@ class MesosRecordIoStorageClient(
         while (position < chunk.size()) {
           if (currentRecordSize == -1) {
 
-            val newlineIndex = chunk.indexOf(recordDelimiter, position)
+            val newlineIndex = chunk.indexOf(RECORD_DELIMITER, position)
             if (newlineIndex != -1) {
               require(newlineIndex != position)
               recordSizeBuffer.append(
@@ -163,6 +160,7 @@ class MesosRecordIoStorageClient(
   }
 
   companion object {
+    private val RECORD_DELIMITER = "\n".toByteStringUtf8()
     private val logger = Logger.getLogger(this::class.java.name)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -17,7 +17,6 @@ package org.wfanet.measurement.storage
 import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteStringUtf8
 import java.util.logging.Logger
-import kotlin.ByteArray
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -38,8 +38,6 @@ class MesosRecordIoStorageClient(
   private val recordDelimiter: ByteString = "\n".toByteStringUtf8(),
 ) : StorageClient {
 
-  // private val recordDelimiterBytes = recordDelimiter.toByteArray()
-
   /**
    * Writes RecordIO rows to storage using the RecordIO format.
    *

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -16,9 +16,9 @@ package org.wfanet.measurement.storage
 
 import com.google.protobuf.ByteString
 import java.util.logging.Logger
+import kotlin.ByteArray
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlin.ByteArray
 
 /**
  * A wrapper class for the [StorageClient] interface that handles Apache Mesos RecordIO formatted
@@ -57,7 +57,8 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
       content.collect { byteString ->
         val byteArray = byteString.toByteArray()
         val recordSize: String = byteArray.size.toString()
-        val fullRecordBytes: ByteArray = (recordSize + RECORD_DELIMITER).toByteArray(Charsets.UTF_8) + byteArray
+        val fullRecordBytes: ByteArray =
+          (recordSize + RECORD_DELIMITER).toByteArray(Charsets.UTF_8) + byteArray
         outputStream.write(fullRecordBytes)
         recordsWritten++
         emit(outputStream.toByteString())
@@ -128,7 +129,9 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
             val newlineIndex = chunkByteArray.indexOf(RECORD_DELIMITER, position)
             if (newlineIndex != -1) {
               require(newlineIndex != position)
-              recordSizeBuffer.append(chunkByteArray.sliceArray(position until newlineIndex).toString(Charsets.UTF_8))
+              recordSizeBuffer.append(
+                chunkByteArray.sliceArray(position until newlineIndex).toString(Charsets.UTF_8)
+              )
               currentRecordSize = recordSizeBuffer.toString().toInt()
               recordSizeBuffer.clear()
               recordBuffer = ByteString.newOutput(currentRecordSize)
@@ -143,9 +146,7 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
             val bytesToRead = minOf(remainingBytes, currentRecordSize - recordBuffer.size())
 
             if (bytesToRead > 0) {
-              recordBuffer.write(
-                chunkByteArray.sliceArray(position until position + bytesToRead)
-              )
+              recordBuffer.write(chunkByteArray.sliceArray(position until position + bytesToRead))
               position += bytesToRead
             }
             if (recordBuffer.size() == currentRecordSize) {

--- a/src/main/proto/wfa/measurement/storage/testing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/storage/testing/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_proto_library")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+IMPORT_PREFIX = "/src/main/proto"
+
+proto_library(
+    name = "complex_message_proto",
+    srcs = ["complex_message.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "complex_message_kt_jvm_proto",
+    deps = [":complex_message_proto"],
+)

--- a/src/main/proto/wfa/measurement/storage/testing/complex_message.proto
+++ b/src/main/proto/wfa/measurement/storage/testing/complex_message.proto
@@ -1,0 +1,37 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.wfa.measurement.storage.testing;
+
+option java_package = "org.wfanet.measurement.storage.testing";
+option java_multiple_files = true;
+
+message ComplexMessage {
+  enum Enum {
+    STATE_UNKNOWN = 0;
+    STATE_1 = 1;
+    STATE_2 = 2;
+  }
+  message SubMessage {
+    repeated int32 field1 = 1;
+    Enum field2 = 2;
+    string field3 = 3;
+    uint64 field4 = 4;
+  }
+  repeated int32 field1 = 1;
+  repeated SubMessage field2 = 2;
+  double field3 = 3;
+}

--- a/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -2,8 +2,8 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 
 kt_jvm_test(
     name = "MesosRecordIoStorageClientTest",
-    srcs = ["MesosRecordIoStorageClientTest.kt"],
     timeout = "short",
+    srcs = ["MesosRecordIoStorageClientTest.kt"],
     deps = [
         "//imports/java/com/google/common/truth",
         "//imports/java/org/junit",

--- a/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -3,6 +3,7 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 kt_jvm_test(
     name = "MesosRecordIoStorageClientTest",
     srcs = ["MesosRecordIoStorageClientTest.kt"],
+    timeout = "short",
     deps = [
         "//imports/java/com/google/common/truth",
         "//imports/java/org/junit",

--- a/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -8,5 +8,6 @@ kt_jvm_test(
         "//imports/java/org/junit",
         "//src/main/kotlin/org/wfanet/measurement/storage:mesos_recordio_storage_client",
         "//src/main/kotlin/org/wfanet/measurement/storage/testing",
+        "//src/main/proto/wfa/measurement/storage/testing:complex_message_kt_jvm_proto",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
@@ -18,11 +18,10 @@ package org.wfanet.measurement.storage
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
-import java.lang.NumberFormatException
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -167,9 +166,7 @@ class MesosRecordIoStorageClientTest {
 
       when {
         !invalidContent.startsWith("100") -> {
-          assertFailsWith<IllegalArgumentException> {
-            blob.read().collect {}
-          }
+          assertFailsWith<IllegalArgumentException> { blob.read().collect {} }
         }
         else -> {
           blob.read().collect {}
@@ -180,12 +177,13 @@ class MesosRecordIoStorageClientTest {
 
   @Test
   fun `test writing and reading multiple complex records`() = runBlocking {
-    val testSubMessage = ComplexMessageKt.subMessage{
-      field1 += listOf(1, 2, 3)
-      field2 = ComplexMessage.Enum.STATE_2
-      field3 = (1..1000).map { ('a'..'z').random() }.joinToString("")
-      field4 = 100L
-    }
+    val testSubMessage =
+      ComplexMessageKt.subMessage {
+        field1 += listOf(1, 2, 3)
+        field2 = ComplexMessage.Enum.STATE_2
+        field3 = (1..1000).map { ('a'..'z').random() }.joinToString("")
+        field4 = 100L
+      }
     val testData = complexMessage {
       field1 += listOf(1, 2, 3)
       field2 += listOf(testSubMessage, testSubMessage)

--- a/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
@@ -22,6 +22,7 @@ import java.lang.NumberFormatException
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -30,7 +31,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.wfanet.measurement.storage.testing.ComplexMessage
+import org.wfanet.measurement.storage.testing.ComplexMessageKt
 import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+import org.wfanet.measurement.storage.testing.complexMessage
 
 @RunWith(JUnit4::class)
 class MesosRecordIoStorageClientTest {
@@ -162,17 +166,8 @@ class MesosRecordIoStorageClientTest {
       requireNotNull(blob) { "Blob should exist" }
 
       when {
-        invalidContent.startsWith("-5") -> {
-          assertFailsWith<IllegalArgumentException>(
-            "Expected IllegalArgumentException for content: $invalidContent"
-          ) {
-            blob.read().collect {}
-          }
-        }
         !invalidContent.startsWith("100") -> {
-          assertFailsWith<NumberFormatException>(
-            "Expected NumberFormatException for content: $invalidContent"
-          ) {
+          assertFailsWith<IllegalArgumentException> {
             blob.read().collect {}
           }
         }
@@ -180,6 +175,32 @@ class MesosRecordIoStorageClientTest {
           blob.read().collect {}
         }
       }
+    }
+  }
+
+  @Test
+  fun `test writing and reading multiple complex records`() = runBlocking {
+    val testSubMessage = ComplexMessageKt.subMessage{
+      field1 += listOf(1, 2, 3)
+      field2 = ComplexMessage.Enum.STATE_2
+      field3 = (1..1000).map { ('a'..'z').random() }.joinToString("")
+      field4 = 100L
+    }
+    val testData = complexMessage {
+      field1 += listOf(1, 2, 3)
+      field2 += listOf(testSubMessage, testSubMessage)
+      field3 = 100.0
+    }
+    val numRecords = 2
+    val blobKey = "test-single-record"
+    val data: Flow<ByteString> = flow { repeat(numRecords) { emit(testData.toByteString()) } }
+    mesosRecordIoStorageClient.writeBlob(blobKey, data)
+    val blob = mesosRecordIoStorageClient.getBlob(blobKey)
+    requireNotNull(blob) { "Blob should exist" }
+    val records = blob.read().toList()
+    assertThat(records.size).isEqualTo(numRecords)
+    for (record in records) {
+      assertThat(testData).isEqualTo(ComplexMessage.parseFrom(record))
     }
   }
 }


### PR DESCRIPTION
We saw the mesos storage client fail with complex message types. 

I believe the error occurred because the prior code converts everything to a String and that isn't always possible with the underlying data.

Note that the new added test hangs with the old code but now succeeds.