### PR TITLE
feat!: Allow a grace period for in-flight RPCs to complete

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Instrumentation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Instrumentation.kt
@@ -23,10 +23,12 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.BatchCallback
 import io.opentelemetry.api.metrics.Meter
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.ThreadPoolExecutor
 
-private interface InstrumentationInterface {
+interface Instrumentation {
+  /** Instrumentation handle which cleans up instrumentation on [close]. */
+  interface Handle : AutoCloseable
+
   /** Singleton [OpenTelemetry] instance which may be initialized by the Java agent. */
   val openTelemetry: OpenTelemetry
 
@@ -34,15 +36,50 @@ private interface InstrumentationInterface {
   val meter: Meter
 
   /**
-   * Instruments the [ThreadPoolExecutor].
+   * Instruments [threadPool] as [poolName].
    *
-   * @return the instrumented [ExecutorService]
+   * @return a [Handle] for cleaning up instrumentation
+   * @throws IllegalStateException if a thread pool with [poolName] has already been instrumented by
+   *   this instance
    */
-  fun instrumentThreadPool(poolName: String, threadPool: ThreadPoolExecutor): ExecutorService
+  fun instrumentThreadPool(poolName: String, threadPool: ThreadPoolExecutor): Handle
+
+  companion object : Instrumentation {
+    /** Root namespace. */
+    const val ROOT_NAMESPACE = "halo_cmm"
+
+    private val instance = invalidatableLazy {
+      // Delayed instantiation to avoid accessing global OpenTelemetry instance before it's ready.
+      InstrumentationImpl(GlobalOpenTelemetry.get())
+    }
+
+    override val openTelemetry: OpenTelemetry
+      get() = instance.value.openTelemetry
+
+    override val meter: Meter
+      get() = instance.value.meter
+
+    override fun instrumentThreadPool(poolName: String, threadPool: ThreadPoolExecutor) =
+      instance.value.instrumentThreadPool(poolName, threadPool)
+
+    /**
+     * Resets [Instrumentation].
+     *
+     * This should only be used for tests.
+     */
+    fun resetForTest() {
+      if (!instance.isInitialized()) {
+        return
+      }
+
+      instance.value.close()
+      instance.invalidate()
+    }
+  }
 }
 
-class Instrumentation internal constructor(override val openTelemetry: OpenTelemetry) :
-  InstrumentationInterface {
+private class InstrumentationImpl(override val openTelemetry: OpenTelemetry) :
+  Instrumentation, AutoCloseable {
   override val meter: Meter = openTelemetry.getMeter(this::class.java.name)
 
   private val threadPools = ThreadPools(meter)
@@ -50,7 +87,11 @@ class Instrumentation internal constructor(override val openTelemetry: OpenTelem
   override fun instrumentThreadPool(
     poolName: String,
     threadPool: ThreadPoolExecutor,
-  ): ExecutorService = threadPools.instrument(poolName, threadPool)
+  ): Instrumentation.Handle = threadPools.instrument(poolName, threadPool)
+
+  override fun close() {
+    threadPools.close()
+  }
 
   private class ThreadPools(meter: Meter) : AutoCloseable {
     private val threadPoolsByName = ConcurrentHashMap<String, ThreadPoolExecutor>()
@@ -69,10 +110,10 @@ class Instrumentation internal constructor(override val openTelemetry: OpenTelem
       meter.batchCallback(::record, sizeCounter, activeCounter)
 
     /** Registers the specified thread pool for instrumentation. */
-    fun instrument(poolName: String, threadPool: ThreadPoolExecutor): ExecutorService {
+    fun instrument(poolName: String, threadPool: ThreadPoolExecutor): Instrumentation.Handle {
       val previousRegistration = threadPoolsByName.putIfAbsent(poolName, threadPool)
       check(previousRegistration == null) { "Thread pool $poolName already instrumented" }
-      return InstrumentedExecutorService(poolName, threadPool)
+      return ThreadPoolHandle(poolName, threadPool)
     }
 
     private fun record() {
@@ -88,70 +129,20 @@ class Instrumentation internal constructor(override val openTelemetry: OpenTelem
       threadPoolsByName.clear()
     }
 
-    /** Instrumented [ExecutorService] */
-    private inner class InstrumentedExecutorService(
+    inner class ThreadPoolHandle(
       private val poolName: String,
-      private val delegate: ExecutorService,
-    ) : ExecutorService by delegate {
-      override fun shutdown() {
-        threadPoolsByName.remove(poolName)
-        delegate.shutdown()
-      }
-
-      override fun shutdownNow(): MutableList<Runnable> {
-        threadPoolsByName.remove(poolName)
-        return delegate.shutdownNow()
+      private val threadPool: ThreadPoolExecutor,
+    ) : Instrumentation.Handle {
+      override fun close() {
+        threadPoolsByName.remove(poolName, threadPool)
       }
     }
 
     companion object {
-      private const val NAMESPACE = "$ROOT_NAMESPACE.thread_pool"
+      private const val NAMESPACE = "${Instrumentation.ROOT_NAMESPACE}.thread_pool"
       /** Attribute key for thread pool name. */
       private val THREAD_POOL_NAME_ATTRIBUTE_KEY: AttributeKey<String> =
         AttributeKey.stringKey("$NAMESPACE.name")
     }
   }
-
-  companion object : InstrumentationInterface {
-    /** Root namespace. */
-    const val ROOT_NAMESPACE = "halo_cmm"
-
-    private val instance = invalidatableLazy {
-      // Delayed instantiation to avoid accessing global OpenTelemetry instance before it's ready.
-      Instrumentation(GlobalOpenTelemetry.get())
-    }
-
-    override val openTelemetry: OpenTelemetry
-      get() = instance.value.openTelemetry
-
-    override val meter: Meter
-      get() = instance.value.meter
-
-    override fun instrumentThreadPool(
-      poolName: String,
-      threadPool: ThreadPoolExecutor,
-    ): ExecutorService = instance.value.instrumentThreadPool(poolName, threadPool)
-
-    /**
-     * Unsets [Instrumentation].
-     *
-     * This should only be used for tests.
-     */
-    fun resetForTest() {
-      if (!instance.isInitialized()) {
-        return
-      }
-
-      instance.value.threadPools.close()
-      instance.invalidate()
-    }
-  }
 }
-
-/**
- * Instruments the [ThreadPoolExecutor].
- *
- * @return the instrumented [ExecutorService]
- */
-fun ThreadPoolExecutor.instrumented(poolName: String): ExecutorService =
-  Instrumentation.instrumentThreadPool(poolName, this)

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
@@ -24,7 +24,6 @@ import io.grpc.protobuf.services.ProtoReflectionServiceV1
 import io.netty.handler.ssl.ClientAuth
 import io.netty.handler.ssl.SslContext
 import java.io.IOException
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -32,9 +31,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.properties.Delegates
-import org.jetbrains.annotations.VisibleForTesting
+import org.jetbrains.annotations.Blocking
+import org.wfanet.measurement.common.Instrumentation
 import org.wfanet.measurement.common.crypto.SigningCerts
-import org.wfanet.measurement.common.instrumented
 import picocli.CommandLine
 
 class CommonServer
@@ -43,17 +42,18 @@ private constructor(
   port: Int,
   healthPort: Int,
   threadPoolSize: Int,
+  private val shutdownGracePeriodSeconds: Int,
   verboseGrpcLogging: Boolean,
   services: Iterable<ServerServiceDefinition>,
   sslContext: SslContext?,
-) {
+) : AutoCloseable {
   init {
     require(threadPoolSize > 1)
   }
 
-  private val executor: ExecutorService =
+  private val executor =
     ThreadPoolExecutor(1, threadPoolSize, 60L, TimeUnit.SECONDS, LinkedBlockingQueue())
-      .instrumented(nameForLogging)
+  private lateinit var instrumentationHandle: Instrumentation.Handle
   private val healthStatusManager = HealthStatusManager()
   private val started = AtomicBoolean(false)
 
@@ -63,13 +63,7 @@ private constructor(
   val healthPort: Int
     get() = healthServer.port
 
-  /**
-   * Internal [Server].
-   *
-   * Visible only for testing.
-   */
-  @get:VisibleForTesting
-  internal val server: Server by lazy {
+  private val server: Server by lazy {
     logger.info { "$nameForLogging thread pool size: $threadPoolSize" }
     if (verboseGrpcLogging) {
       logger.info { "$nameForLogging verbose gRPC server logging enabled" }
@@ -101,10 +95,30 @@ private constructor(
       .build()
   }
 
-  @Throws(IOException::class)
+  private val shutdownHook =
+    object : Thread() {
+      override fun run() {
+        // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+        System.err.println("*** $nameForLogging shutting down...")
+
+        shutdown()
+        try {
+          // Wait for in-flight RPCs to complete.
+          server.awaitTermination(shutdownGracePeriodSeconds.toLong(), TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+          currentThread().interrupt()
+        }
+        shutdownNow()
+
+        System.err.println("*** $nameForLogging shut down")
+      }
+    }
+
   @Synchronized
+  @Throws(IOException::class)
   fun start(): CommonServer {
     check(!started.get()) { "$nameForLogging already started" }
+    instrumentationHandle = Instrumentation.instrumentThreadPool(nameForLogging, executor)
     server.start()
     server.services.forEach {
       healthStatusManager.setStatus(it.serviceDescriptor.name, ServingStatus.SERVING)
@@ -112,18 +126,7 @@ private constructor(
     healthServer.start()
 
     logger.log(Level.INFO, "$nameForLogging started, listening on $port")
-    Runtime.getRuntime()
-      .addShutdownHook(
-        object : Thread() {
-          override fun run() {
-            // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-            System.err.println("*** $nameForLogging shutting down...")
-            this@CommonServer.shutdown()
-            blockUntilShutdown()
-            System.err.println("*** $nameForLogging shut down")
-          }
-        }
-      )
+    Runtime.getRuntime().addShutdownHook(shutdownHook)
     started.set(true)
     return this
   }
@@ -135,9 +138,18 @@ private constructor(
 
     healthServer.shutdown()
     server.shutdown()
-    executor.shutdown()
   }
 
+  private fun shutdownNow() {
+    if (!started.get()) {
+      return
+    }
+
+    healthServer.shutdownNow()
+    server.shutdownNow()
+  }
+
+  @Blocking
   @Throws(InterruptedException::class)
   fun blockUntilShutdown() {
     if (!started.get()) {
@@ -146,7 +158,35 @@ private constructor(
 
     server.awaitTermination()
     healthServer.awaitTermination()
-    executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)
+  }
+
+  private val terminated: Boolean
+    get() = server.isTerminated && healthServer.isTerminated
+
+  override fun close() {
+    if (!started.get()) {
+      return
+    }
+
+    Runtime.getRuntime().removeShutdownHook(shutdownHook)
+
+    var interrupted = false
+    shutdown()
+    while (!terminated) {
+      try {
+        blockUntilShutdown()
+      } catch (e: InterruptedException) {
+        if (!interrupted) {
+          shutdownNow()
+          interrupted = true
+        }
+      }
+    }
+
+    instrumentationHandle.close()
+    if (interrupted) {
+      Thread.currentThread().interrupt()
+    }
   }
 
   class Flags {
@@ -192,11 +232,20 @@ private constructor(
     )
     var debugVerboseGrpcLogging by Delegates.notNull<Boolean>()
       private set
+
+    @set:CommandLine.Option(
+      names = ["--shutdown-grace-period-seconds"],
+      description = ["Duration of the \"grace period\" for graceful shutdown in seconds"],
+      defaultValue = DEFAULT_SHUTDOWN_GRACE_PERIOD_SECONDS.toString(),
+    )
+    var shutdownGracePeriodSeconds by Delegates.notNull<Int>()
+      private set
   }
 
   companion object {
     private val logger = Logger.getLogger(this::class.java.name)
 
+    const val DEFAULT_SHUTDOWN_GRACE_PERIOD_SECONDS = 25
     val DEFAULT_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2
 
     /** Constructs a [CommonServer] from parameters. */
@@ -209,12 +258,14 @@ private constructor(
       port: Int = 0,
       healthPort: Int = 0,
       threadPoolSize: Int = DEFAULT_THREAD_POOL_SIZE,
+      shutdownGracePeriodSeconds: Int = DEFAULT_SHUTDOWN_GRACE_PERIOD_SECONDS,
     ): CommonServer {
       return CommonServer(
         nameForLogging,
         port,
         healthPort,
         threadPoolSize,
+        shutdownGracePeriodSeconds,
         verboseGrpcLogging,
         services,
         certs?.toServerTlsContext(clientAuth),
@@ -236,6 +287,7 @@ private constructor(
         flags.port,
         flags.healthPort,
         flags.threadPoolSize,
+        flags.shutdownGracePeriodSeconds,
       )
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -34,7 +34,6 @@ kt_jvm_test(
         "//imports/java/org/junit",
         "//imports/kotlin/io/grpc/health/v1:health_kt_jvm_grpc_proto",
         "//imports/kotlin/kotlin/test",
-        "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
     ],
 )


### PR DESCRIPTION
In particular, do not shut down the gRPC server executor explicitly prior to the grace period.

RELNOTES: gRPC servers now support a grace period to allow in-flight RPCs to complete when shutting down. This can be controlled by the `--shutdown-grace-period-seconds` option.
BREAKING CHANGE: `Instrumentation.instrumentThreadPool` returns a handle for cleanup instead of an `ExecutorService` that cleans up on shutdown.