### PR TITLE
ci: Update workflows to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build-test:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out revision
       uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   lint:
     name: Lint changed files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
ubuntu-20.04 has been turned down, so workflows using it cannot run.