### PR TITLE
feat!: Include a default ServiceConfig for all gRPC channels

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -19,6 +19,7 @@ kt_jvm_library(
         "//imports/java/org/jetbrains/annotations",
         "//imports/java/picocli",
         "//imports/kotlin/io/grpc/kotlin:stub",
+        "//imports/kotlin/io/grpc/service_config:service_config_kt_jvm_proto",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/ServiceConfig.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/ServiceConfig.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.grpc
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.google.protobuf.util.Durations
+import com.google.rpc.Code
+import io.grpc.serviceconfig.MethodConfigKt
+import io.grpc.serviceconfig.ServiceConfigKt
+import io.grpc.serviceconfig.copy
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
+import org.wfanet.measurement.common.toJson
+
+private val GSON = Gson()
+private val SERVICE_CONFIG_MAP_TYPE = object : TypeToken<Map<String, *>>() {}.type
+
+/** Immutable gRPC service configuration. */
+sealed interface ServiceConfig {
+  /** Returns the configuration as a JSON object map. */
+  fun asMap(): Map<String, *>
+}
+
+/** [ServiceConfig] with JSON representation. */
+data class JsonServiceConfig(val json: String) : ServiceConfig {
+  override fun asMap(): Map<String, *> {
+    return GSON.fromJson(json, SERVICE_CONFIG_MAP_TYPE)
+  }
+}
+
+/** [ServiceConfig] with protobuf message representation. */
+data class ProtobufServiceConfig(val message: io.grpc.serviceconfig.ServiceConfig) : ServiceConfig {
+  fun asJson() = JsonServiceConfig(message.toJson())
+
+  override fun asMap() = asJson().asMap()
+
+  /** Returns a copy of this [ProtobufServiceConfig] with message modified by [fill]. */
+  fun copy(fill: ServiceConfigKt.Dsl.() -> Unit): ProtobufServiceConfig {
+    return ProtobufServiceConfig(message.copy(fill))
+  }
+
+  companion object {
+    val DEFAULT =
+      ProtobufServiceConfig(
+        serviceConfig {
+          methodConfig += methodConfig {
+            timeout = Durations.fromSeconds(30)
+            retryPolicy =
+              MethodConfigKt.retryPolicy {
+                retryableStatusCodes += Code.UNAVAILABLE
+                maxAttempts = 10
+                initialBackoff = Durations.fromMillis(100)
+                maxBackoff = Durations.fromSeconds(1)
+                backoffMultiplier = 1.5f
+              }
+          }
+        }
+      )
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/GrpcTestServerRule.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/GrpcTestServerRule.kt
@@ -27,12 +27,14 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.wfanet.measurement.common.grpc.ErrorLoggingServerInterceptor
 import org.wfanet.measurement.common.grpc.LoggingServerInterceptor
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
+import org.wfanet.measurement.common.grpc.ServiceConfig
 
 class GrpcTestServerRule(
   customServerName: String? = null,
   private val logAllRequests: Boolean = false,
   private val executor: Executor? = null,
-  defaultServiceConfig: Map<String, *>? = null,
+  defaultServiceConfig: ServiceConfig = ProtobufServiceConfig.DEFAULT,
   private val addServices: Builder.() -> Unit,
 ) : TestRule {
   class Builder(val channel: Channel, private val serverBuilder: InProcessServerBuilder) {
@@ -53,9 +55,7 @@ class GrpcTestServerRule(
       InProcessChannelBuilder.forName(serverName)
         .apply {
           directExecutor()
-          if (defaultServiceConfig != null) {
-            defaultServiceConfig(defaultServiceConfig)
-          }
+          defaultServiceConfig(defaultServiceConfig.asMap())
         }
         .build()
     )


### PR DESCRIPTION
This retries on UNAVAILABLE status with backoff and includes a deadline.

BREAKING CHANGE: The `defaultServiceConfig` param for building channels now takes a `ServiceConfig` object instead of a map.