### PR TITLE
fix: register aeadconfig before parsing

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -146,7 +146,6 @@ class StreamingAeadStorageClient(
     private val logger = Logger.getLogger(this::class.java.name)
 
     init {
-      AeadConfig.register()
       StreamingAeadConfig.register()
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -15,7 +15,6 @@
 package org.wfanet.measurement.common.crypto.tink
 
 import com.google.crypto.tink.StreamingAead
-import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.ByteString
 import java.nio.channels.ClosedChannelException

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -15,6 +15,8 @@
 package org.wfanet.measurement.common.crypto.tink
 
 import com.google.crypto.tink.StreamingAead
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.ByteString
 import java.nio.channels.ClosedChannelException
 import java.util.logging.Logger
@@ -34,8 +36,6 @@ import org.wfanet.measurement.common.CoroutineReadableByteChannel
 import org.wfanet.measurement.common.CoroutineWritableByteChannel
 import org.wfanet.measurement.common.asFlow
 import org.wfanet.measurement.storage.StorageClient
-import com.google.crypto.tink.aead.AeadConfig
-import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 
 /**
  * A wrapper class for the [StorageClient] interface that leverages Tink AEAD encryption/decryption
@@ -149,6 +149,5 @@ class StreamingAeadStorageClient(
       AeadConfig.register()
       StreamingAeadConfig.register()
     }
-
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -34,6 +34,8 @@ import org.wfanet.measurement.common.CoroutineReadableByteChannel
 import org.wfanet.measurement.common.CoroutineWritableByteChannel
 import org.wfanet.measurement.common.asFlow
 import org.wfanet.measurement.storage.StorageClient
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 
 /**
  * A wrapper class for the [StorageClient] interface that leverages Tink AEAD encryption/decryption
@@ -142,5 +144,11 @@ class StreamingAeadStorageClient(
 
   companion object {
     private val logger = Logger.getLogger(this::class.java.name)
+
+    init {
+      AeadConfig.register()
+      StreamingAeadConfig.register()
+    }
+
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/WithEnvelopeEncryption.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/WithEnvelopeEncryption.kt
@@ -19,6 +19,7 @@ import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.StreamingAead
 import com.google.crypto.tink.TinkProtoKeysetFormat
+import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadKey
 import com.google.protobuf.ByteString
@@ -41,6 +42,10 @@ fun StorageClient.withEnvelopeEncryption(
   encryptedDek: ByteString,
   aeadContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
 ): StorageClient {
+
+  AeadConfig.register()
+  StreamingAeadConfig.register()
+
   val storageClient = this
   val kekAead = kmsClient.getAead(kekUri)
   val handle: KeysetHandle =
@@ -48,7 +53,6 @@ fun StorageClient.withEnvelopeEncryption(
   return when (val primaryKey: Key = handle.primary.key) {
     is StreamingAeadKey -> {
 
-      StreamingAeadConfig.register()
       StreamingAeadStorageClient(
         storageClient = storageClient,
         streamingAead = handle.getPrimitive(StreamingAead::class.java),

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/WithEnvelopeEncryption.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/WithEnvelopeEncryption.kt
@@ -19,8 +19,6 @@ import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.StreamingAead
 import com.google.crypto.tink.TinkProtoKeysetFormat
-import com.google.crypto.tink.aead.AeadConfig
-import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadKey
 import com.google.protobuf.ByteString
 import kotlin.coroutines.CoroutineContext
@@ -42,9 +40,6 @@ fun StorageClient.withEnvelopeEncryption(
   encryptedDek: ByteString,
   aeadContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
 ): StorageClient {
-
-  AeadConfig.register()
-  StreamingAeadConfig.register()
 
   val storageClient = this
   val kekAead = kmsClient.getAead(kekUri)

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/WithEnvelopeEncryption.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/WithEnvelopeEncryption.kt
@@ -19,6 +19,7 @@ import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.StreamingAead
 import com.google.crypto.tink.TinkProtoKeysetFormat
+import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadKey
 import com.google.protobuf.ByteString
 import kotlin.coroutines.CoroutineContext
@@ -40,6 +41,8 @@ fun StorageClient.withEnvelopeEncryption(
   encryptedDek: ByteString,
   aeadContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
 ): StorageClient {
+
+  AeadConfig.register()
 
   val storageClient = this
   val kekAead = kmsClient.getAead(kekUri)


### PR DESCRIPTION
`val handle: KeysetHandle =
    TinkProtoKeysetFormat.parseEncryptedKeyset(encryptedDek.toByteArray(), kekAead, byteArrayOf())`

errors `Unsupported Key Type: LegacyProtoKey`.

That happens because the `StreamingAeadConfig` is registered after the parser generates the `KeysetHandle`. So the parses fallback to `LegacyProto` which is not supported.

This PR fixes the problem by registering the Config before the parser runs. 