### PR TITLE
fix: bug with record size splitted across chunks

### DIFF
--- a/src/main/kotlin/module-info.java
+++ b/src/main/kotlin/module-info.java
@@ -1,0 +1,3 @@
+module workspace {
+    requires kotlin.stdlib;
+}

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -128,7 +128,9 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
 
             val newlineIndex = chunk.indexOf(RECORD_DELIMITER, position)
             if (newlineIndex != -1) {
-              require(newlineIndex != position)
+              require(recordSizeBuffer.isNotEmpty() || newlineIndex > position) {
+                "Record size is missing."
+              }
               recordSizeBuffer.append(
                 chunk.substring(position, newlineIndex).toString(Charsets.UTF_8)
               )
@@ -137,7 +139,7 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
               recordBuffer = ByteString.newOutput(currentRecordSize)
               position = newlineIndex + 1
             } else {
-              recordSizeBuffer.append(chunk)
+              recordSizeBuffer.append(chunk.substring(position, chunk.size()).toStringUtf8())
               break
             }
           }


### PR DESCRIPTION
Two bugs:

1. `require(newlineIndex > position)` only is wrong as `newlineIndex` can indeed be at position 0 in case `recordSizeBuffer` already contains the record size. This is the case where `recordSizeBuffer` is the last piece of previous chunk and  `newlineIndex` is the first char of the next chunk (e.g. chunk1(....119), chunk2(\n...) ).
2. in case the record size is splitted across two chunks (e.g. chunk1(....11), chunk2(9\n...) ), the digits on previous chunk were wrongly passed to the following chunk