### PR TITLE
perf: Add statement_timeout to Postgres Client Connections

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/db/r2dbc/postgres/PostgresDatabaseClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/db/r2dbc/postgres/PostgresDatabaseClient.kt
@@ -21,6 +21,7 @@ import io.r2dbc.spi.ConnectionFactories
 import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.ConnectionFactoryOptions
 import io.r2dbc.spi.IsolationLevel
+import java.time.Duration
 import kotlinx.coroutines.reactive.awaitSingle
 import org.wfanet.measurement.common.db.postgres.PostgresFlags
 import org.wfanet.measurement.common.db.r2dbc.ConnectionProvider
@@ -51,6 +52,7 @@ class PostgresDatabaseClient(getConnection: ConnectionProvider) : DatabaseClient
             .option(ConnectionFactoryOptions.USER, flags.user)
             .option(ConnectionFactoryOptions.PASSWORD, flags.password)
             .option(ConnectionFactoryOptions.DATABASE, flags.database)
+            .option(ConnectionFactoryOptions.STATEMENT_TIMEOUT, Duration.ofSeconds(60))
             .build()
         )
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/postgres/PostgresConnectionFactories.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/postgres/PostgresConnectionFactories.kt
@@ -18,6 +18,7 @@ import com.google.cloud.sql.core.GcpConnectionFactoryProvider
 import io.r2dbc.spi.ConnectionFactories
 import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.ConnectionFactoryOptions
+import java.time.Duration
 
 object PostgresConnectionFactories {
   @JvmStatic
@@ -32,6 +33,7 @@ object PostgresConnectionFactories {
         .option(ConnectionFactoryOptions.DATABASE, flags.database)
         .option(ConnectionFactoryOptions.HOST, flags.cloudSqlInstance)
         .option(GcpConnectionFactoryProvider.ENABLE_IAM_AUTH, true)
+        .option(ConnectionFactoryOptions.STATEMENT_TIMEOUT, Duration.ofSeconds(60))
         .build()
     )
   }


### PR DESCRIPTION
Set statement_timeout to 60s for Postgres connections.

Issue: #335 