### PR TITLE
fix!: Ensure that StreamingAeadStorageClient writes all bytes

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Bytes.kt
@@ -359,6 +359,32 @@ fun String.hexAsByteString(): ByteString {
 }
 
 /**
+ * Copies as many bytes as will fit from [src] to this buffer.
+ *
+ * This behaves the same as [ByteBuffer.put], except that it does not throw a
+ * [java.nio.BufferOverflowException].
+ *
+ * @return the number of bytes copied into this buffer
+ */
+fun ByteBuffer.tryPut(src: ByteBuffer): Int {
+  if (!hasRemaining() || !src.hasRemaining()) {
+    return 0
+  }
+
+  val remainingCapacity: Int = remaining()
+  val srcRemaining: Int = src.remaining()
+  return if (srcRemaining > remainingCapacity) {
+    val slice: ByteBuffer = src.slice().limit(remainingCapacity)
+    put(slice)
+    src.position(src.position() + remainingCapacity)
+    remainingCapacity
+  } else {
+    put(src)
+    srcRemaining
+  }
+}
+
+/**
  * Reads a varint from a ByteBuffer. Varints are variable-width unsigned integers, supporting up to
  * 64-bit integers.
  *

--- a/src/main/kotlin/org/wfanet/measurement/common/CoroutineReadableByteChannel.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/CoroutineReadableByteChannel.kt
@@ -16,8 +16,9 @@ package org.wfanet.measurement.common
 
 import com.google.protobuf.ByteString
 import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
 import java.nio.channels.ReadableByteChannel
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.channels.ReceiveChannel
 
 /**
@@ -26,63 +27,55 @@ import kotlinx.coroutines.channels.ReceiveChannel
  * coroutine channel.
  *
  * @property delegate The [ReceiveChannel] from which this [ReadableByteChannel] will read data.
- * @constructor Creates a readable channel that reads each [ByteString] from the provided
- *   [ReceiveChannel] and writes it to the specified [ByteBuffer].
  */
 class CoroutineReadableByteChannel(private val delegate: ReceiveChannel<ByteString>) :
   ReadableByteChannel {
 
-  private var remainingBuffer: ByteBuffer = ByteString.EMPTY.asReadOnlyByteBuffer()
+  private var closed = false
 
-  /**
-   * Reads bytes from the [ReceiveChannel] and transfers them into the provided buffer. If there are
-   * leftover bytes from a previous read that didn’t fit in the buffer, they are written first.
-   *
-   * When the [ReceiveChannel] has no data available:
-   * - Returns `0` if the channel is open but temporarily empty, allowing the caller to retry later.
-   * - Returns `-1` if the channel is closed and no more data will arrive.
-   *
-   * If only part of a [ByteString] fits into `destination`, the unread portion is saved for future
-   * reads, ensuring data is preserved between calls.
-   *
-   * @param destination The [ByteBuffer] where data will be written.
-   * @return The number of bytes written to `destination`, `0` if no data is available, or `-1` if
-   *   the channel is closed and all data has been read.
-   */
+  /** Buffer of bytes read from [delegate] but not yet read by the caller. */
+  private var sourceBuffer: ByteBuffer = ByteString.EMPTY.asReadOnlyByteBuffer()
+
   override fun read(destination: ByteBuffer): Int {
-    if (remainingBuffer.hasRemaining()) {
-      val bytesWritten = writeToDestination(destination, remainingBuffer)
-      return bytesWritten
+    if (closed) {
+      throw ClosedChannelException()
     }
 
-    val result = delegate.tryReceive()
-    val byteString = result.getOrNull() ?: return if (result.isClosed) -1 else 0
-    remainingBuffer = byteString.asReadOnlyByteBuffer()
-    val bytesWritten = writeToDestination(destination, remainingBuffer)
-    return bytesWritten
+    var writtenCountBytes = 0
+    while (destination.hasRemaining()) {
+      // Read from delegate channel if source buffer is empty.
+      if (!sourceBuffer.hasRemaining()) {
+        val result: ChannelResult<ByteString> = delegate.tryReceive()
+        if (result.isFailure) {
+          if (result.isClosed) {
+            if (writtenCountBytes == 0) {
+              return -1
+            }
+          }
+          return writtenCountBytes
+        }
+
+        val source: ByteString = result.getOrThrow()
+        sourceBuffer = source.asReadOnlyByteBuffer()
+      }
+
+      // Put into destination buffer.
+      if (sourceBuffer.hasRemaining()) {
+        writtenCountBytes += destination.tryPut(sourceBuffer)
+      }
+    }
+
+    return writtenCountBytes
   }
 
-  /**
-   * Transfers bytes from source to destination ByteBuffer, limited by the remaining capacity of
-   * both buffers. Preserves the source buffer's original limit after the transfer.
-   *
-   * @param destination The target ByteBuffer to write data into
-   * @param source The source ByteBuffer to read data from
-   * @return The number of bytes transferred
-   */
-  private fun writeToDestination(destination: ByteBuffer, source: ByteBuffer): Int {
-    val bytesToWrite = minOf(destination.remaining(), source.remaining())
-    val originalLimit = source.limit()
-    source.limit(source.position() + bytesToWrite)
-    destination.put(source)
-    source.limit(originalLimit)
-    return bytesToWrite
-  }
-
-  @OptIn(DelicateCoroutinesApi::class) // Safe usage since read is guarded by tryReceive.
-  override fun isOpen(): Boolean = !delegate.isClosedForReceive
+  override fun isOpen(): Boolean = !closed
 
   override fun close() {
+    if (closed) {
+      return
+    }
+
     delegate.cancel()
+    closed = true
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/BufferedPipe.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/BufferedPipe.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.crypto.tink
+
+import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.ReadableByteChannel
+import java.nio.channels.WritableByteChannel
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import org.wfanet.measurement.common.tryPut
+
+/**
+ * Similar to [java.nio.channels.Pipe], but with a buffer of known [capacity].
+ *
+ * The [write][java.nio.channels.WritableByteChannel.write] method on [sink] should not block while
+ * there is enough remaining space in the buffer to complete the write, assuming there is no
+ * concurrent reader.
+ */
+class BufferedPipe(capacity: Int) : AutoCloseable {
+  private val buffer = ByteBuffer.allocate(capacity)
+  private val lock = ReentrantLock()
+  private val bufferHasRemaining = lock.newCondition()
+
+  /** A channel representing the readable end of a pipe. */
+  val source =
+    object : ReadableByteChannel {
+      private var closed = false
+
+      override fun read(dst: ByteBuffer): Int {
+        if (!isOpen) {
+          throw ClosedChannelException()
+        }
+
+        lock.withLock {
+          buffer.flip()
+          return dst.tryPut(buffer).also {
+            buffer.compact()
+            if (buffer.hasRemaining()) {
+              bufferHasRemaining.signal()
+            }
+          }
+        }
+      }
+
+      override fun isOpen(): Boolean = !closed
+
+      override fun close() {
+        closed = true
+      }
+    }
+
+  /** A channel representing the writable end of a pipe. */
+  val sink =
+    object : WritableByteChannel {
+      private var closed = false
+
+      override fun write(src: ByteBuffer): Int {
+        if (!isOpen) {
+          throw ClosedChannelException()
+        }
+
+        var written = 0
+        lock.withLock {
+          while (src.hasRemaining()) {
+            while (buffer.remaining() < src.remaining()) {
+              bufferHasRemaining.await()
+            }
+            written += buffer.tryPut(src)
+          }
+        }
+
+        return written
+      }
+
+      override fun isOpen(): Boolean = !closed
+
+      override fun close() {
+        closed = true
+      }
+    }
+
+  override fun close() {
+    source.close()
+    sink.close()
+    buffer.clear()
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -17,23 +17,15 @@ package org.wfanet.measurement.common.crypto.tink
 import com.google.crypto.tink.StreamingAead
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
 import java.nio.channels.ClosedChannelException
 import java.util.logging.Logger
 import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.produceIn
-import kotlinx.coroutines.yield
 import org.jetbrains.annotations.BlockingExecutor
 import org.wfanet.measurement.common.BYTES_PER_MIB
-import org.wfanet.measurement.common.CoroutineReadableByteChannel
 import org.wfanet.measurement.common.CoroutineWritableByteChannel
-import org.wfanet.measurement.common.asFlow
 import org.wfanet.measurement.storage.StorageClient
 
 /**
@@ -66,26 +58,10 @@ class StreamingAeadStorageClient(
    * @throws ClosedChannelException if the channel is closed before all data is written.
    */
   override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
-    val encryptedContent = channelFlow {
-      val writableChannel = CoroutineWritableByteChannel(channel)
-
-      streamingAead.newEncryptingChannel(writableChannel, blobKey.encodeToByteArray()).use {
-        ciphertextChannel ->
-        content.collect { byteString ->
-          byteString.asReadOnlyByteBufferList().forEach { buffer ->
-            while (buffer.hasRemaining()) {
-              val bytesWritten = ciphertextChannel.write(buffer)
-              if (bytesWritten == 0) {
-                yield()
-                continue
-              }
-            }
-          }
-        }
-      }
-    }
-
-    val wrappedBlob: StorageClient.Blob = storageClient.writeBlob(blobKey, encryptedContent)
+    val associatedData: ByteString = blobKey.toByteStringUtf8()
+    val ciphertext: Flow<ByteString> =
+      streamingAead.encrypt(content, associatedData, streamingAeadContext)
+    val wrappedBlob: StorageClient.Blob = storageClient.writeBlob(blobKey, ciphertext)
     logger.fine { "Wrote encrypted content to storage with blobKey: $blobKey" }
     return EncryptedBlob(wrappedBlob, blobKey)
   }
@@ -124,24 +100,16 @@ class StreamingAeadStorageClient(
      * @throws java.io.IOException If there is an issue reading from the stream or during
      *   decryption.
      */
-    override fun read(): Flow<ByteString> = flow {
-      val scope = CoroutineScope(streamingAeadContext)
-      try {
-        val chunkChannel = blob.read().produceIn(scope)
-        val readableChannel = CoroutineReadableByteChannel(chunkChannel)
-
-        val plaintextChannel =
-          streamingAead.newDecryptingChannel(readableChannel, blobKey.encodeToByteArray())
-        emitAll(plaintextChannel.asFlow(BYTES_PER_MIB, streamingAeadContext))
-      } finally {
-        scope.cancel()
-      }
+    override fun read(): Flow<ByteString> {
+      val associatedData: ByteString = blobKey.toByteStringUtf8()
+      return streamingAead.decrypt(blob.read(), associatedData, READ_CHUNK_SIZE_BYTES)
     }
 
     override suspend fun delete() = blob.delete()
   }
 
   companion object {
+    private const val READ_CHUNK_SIZE_BYTES = BYTES_PER_MIB
     private val logger = Logger.getLogger(this::class.java.name)
 
     init {

--- a/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingEncryptionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingEncryptionTest.kt
@@ -45,7 +45,7 @@ class StreamingEncryptionTest {
     val chunkSizeBytes = 32 * 1024 // 32 KiB
 
     val ciphertextChunks =
-      StreamingEncryption.encryptChunked(keyHandle, plaintext, chunkSizeBytes, associatedData)
+      StreamingEncryption.encryptChunked(keyHandle, plaintext, associatedData, chunkSizeBytes)
         .toList()
 
     ciphertextChunks.forEachIndexed { index, chunk ->


### PR DESCRIPTION
This removes the workaround of relying on the default channel buffer to ensure that all bytes are written to the underlying coroutine channel by the time the encrypting channel is closed.

BREAKING-CHANGE: CoroutineWritableByteChannel no longer has a public constructor. Instances must instead be created via factory functions.
BREAKING-CHANGE: The StreamingEncryption.encryptChunked signature has changed to mirror the StreamingAead.encrypt signature. In particular, the associatedData param no longer has a default value.
Issue: world-federation-of-advertisers/cross-media-measurement#2594