### PR TITLE
feat: add StorageClient.listBlobsCreatedAfter and StorageClient.listBlobsUpdatedAfter

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.aws.s3
 import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import java.security.MessageDigest
+import java.time.Instant
 import java.util.Base64
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -138,7 +139,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
     val head = head(blobKey) ?: return null
-    return Blob(blobKey, head.contentLength())
+    return Blob(blobKey, head.contentLength(), head.lastModified())
   }
 
   private suspend fun head(blobKey: String): HeadObjectResponse? {
@@ -176,7 +177,10 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
           truncated = listObjectsV2Response.isTruncated
           continuationToken = listObjectsV2Response.nextContinuationToken()
 
-          listObjectsV2Response.contents().map { Blob(it.key(), it.size()) }.forEach { emit(it) }
+          listObjectsV2Response
+            .contents()
+            .map { Blob(it.key(), it.size(), it.lastModified()) }
+            .forEach { emit(it) }
         }
       } catch (e: CompletionException) {
         throw e.cause!!
@@ -184,8 +188,12 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
     }
   }
 
-  inner class Blob internal constructor(override val blobKey: String, contentLength: Long) :
-    StorageClient.Blob {
+  inner class Blob
+  internal constructor(
+    override val blobKey: String,
+    contentLength: Long,
+    override val createTime: Instant? = null,
+  ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@S3StorageClient
 

--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -192,7 +192,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
   internal constructor(
     override val blobKey: String,
     contentLength: Long,
-    override val createTime: Instant? = null,
+    override val createTime: Instant?,
   ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@S3StorageClient

--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -139,7 +139,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
     val head = head(blobKey) ?: return null
-    return Blob(blobKey, head.contentLength(), head.lastModified(), head.lastModified())
+    return Blob(blobKey, head.contentLength(), head.lastModified())
   }
 
   private suspend fun head(blobKey: String): HeadObjectResponse? {
@@ -179,7 +179,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
 
           listObjectsV2Response
             .contents()
-            .map { Blob(it.key(), it.size(), it.lastModified(), it.lastModified()) }
+            .map { Blob(it.key(), it.size(), it.lastModified()) }
             .forEach { emit(it) }
         }
       } catch (e: CompletionException) {
@@ -188,18 +188,26 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
     }
   }
 
-  /**
-   * S3 does not have a separate creation time unless versioning is enabled. Each write replaces the
-   * object entirely, so [lastModified] is both the creation time and update time of the current
-   * version.
-   */
+  /** [StorageClient.Blob] implementation for [S3StorageClient]. */
   inner class Blob
   internal constructor(
     override val blobKey: String,
     contentLength: Long,
-    override val createTime: Instant,
-    override val updateTime: Instant,
+    /**
+     * S3 does not have a separate creation time unless versioning is enabled. Each write replaces
+     * the object entirely, so this is both the creation time and update time of the current
+     * version.
+     */
+    private val lastModified: Instant,
   ) : StorageClient.Blob {
+    /** Always the same as [lastModified]. See [lastModified]. */
+    override val createTime: Instant
+      get() = lastModified
+
+    /** Always the same as [lastModified]. See [lastModified]. */
+    override val updateTime: Instant
+      get() = lastModified
+
     override val storageClient: StorageClient
       get() = this@S3StorageClient
 

--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -192,7 +192,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
   internal constructor(
     override val blobKey: String,
     contentLength: Long,
-    override val createTime: Instant?,
+    override val createTime: Instant,
   ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@S3StorageClient

--- a/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/s3/S3StorageClient.kt
@@ -139,7 +139,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
     val head = head(blobKey) ?: return null
-    return Blob(blobKey, head.contentLength(), head.lastModified())
+    return Blob(blobKey, head.contentLength(), head.lastModified(), head.lastModified())
   }
 
   private suspend fun head(blobKey: String): HeadObjectResponse? {
@@ -179,7 +179,7 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
 
           listObjectsV2Response
             .contents()
-            .map { Blob(it.key(), it.size(), it.lastModified()) }
+            .map { Blob(it.key(), it.size(), it.lastModified(), it.lastModified()) }
             .forEach { emit(it) }
         }
       } catch (e: CompletionException) {
@@ -188,11 +188,17 @@ class S3StorageClient(private val s3: S3AsyncClient, private val bucketName: Str
     }
   }
 
+  /**
+   * S3 does not have a separate creation time unless versioning is enabled. Each write replaces the
+   * object entirely, so [lastModified] is both the creation time and update time of the current
+   * version.
+   */
   inner class Blob
   internal constructor(
     override val blobKey: String,
     contentLength: Long,
     override val createTime: Instant,
+    override val updateTime: Instant,
   ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@S3StorageClient

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/AeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/AeadStorageClient.kt
@@ -78,7 +78,7 @@ class AeadStorageClient(private val storageClient: StorageClient, private val ae
     override val size: Long
       get() = blob.size
 
-    override val createTime: java.time.Instant?
+    override val createTime: java.time.Instant
       get() = blob.createTime
 
     /**

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/AeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/AeadStorageClient.kt
@@ -81,6 +81,9 @@ class AeadStorageClient(private val storageClient: StorageClient, private val ae
     override val createTime: java.time.Instant
       get() = blob.createTime
 
+    override val updateTime: java.time.Instant
+      get() = blob.updateTime
+
     /**
      * Reads and decrypts the blob's content.
      *

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/AeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/AeadStorageClient.kt
@@ -78,6 +78,9 @@ class AeadStorageClient(private val storageClient: StorageClient, private val ae
     override val size: Long
       get() = blob.size
 
+    override val createTime: java.time.Instant?
+      get() = blob.createTime
+
     /**
      * Reads and decrypts the blob's content.
      *

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
@@ -79,7 +79,7 @@ internal constructor(
     StorageClient.Blob {
     override val storageClient = this@KmsStorageClient.storageClient
 
-    override val createTime: java.time.Instant?
+    override val createTime: java.time.Instant
       get() = blob.createTime
 
     override val size: Long

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
@@ -79,6 +79,9 @@ internal constructor(
     StorageClient.Blob {
     override val storageClient = this@KmsStorageClient.storageClient
 
+    override val createTime: java.time.Instant?
+      get() = blob.createTime
+
     override val size: Long
       get() = blob.size
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/KmsStorageClient.kt
@@ -82,6 +82,9 @@ internal constructor(
     override val createTime: java.time.Instant
       get() = blob.createTime
 
+    override val updateTime: java.time.Instant
+      get() = blob.updateTime
+
     override val size: Long
       get() = blob.size
 

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -90,6 +90,9 @@ class StreamingAeadStorageClient(
     override val size: Long
       get() = blob.size
 
+    override val createTime: java.time.Instant?
+      get() = blob.createTime
+
     /**
      * Reads and decrypts the blob's content.
      *

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -93,6 +93,9 @@ class StreamingAeadStorageClient(
     override val createTime: java.time.Instant
       get() = blob.createTime
 
+    override val updateTime: java.time.Instant
+      get() = blob.updateTime
+
     /**
      * Reads and decrypts the blob's content.
      *

--- a/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/crypto/tink/StreamingAeadStorageClient.kt
@@ -90,7 +90,7 @@ class StreamingAeadStorageClient(
     override val size: Long
       get() = blob.size
 
-    override val createTime: java.time.Instant?
+    override val createTime: java.time.Instant
       get() = blob.createTime
 
     /**

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -149,10 +149,12 @@ class GcsStorageClient(
       }
 
     return flow {
-        // When using a delimiter, the GCS API returns "prefix" entries for virtual directories.
-        // The Java client exposes these through Page.getValues() with names ending in the delimiter.
+        // When using a delimiter, the GCS API returns both items and prefix entries.
+        // Only emit prefix entries (names ending with the delimiter), not direct items.
         for (blob: Blob in blobPage.iterateAll()) {
-          emit(blob.name)
+          if (blob.name.endsWith(delimiter)) {
+            emit(blob.name)
+          }
         }
       }
       .flowOn(blockingContext + CoroutineName("listBlobKeys"))

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -204,8 +204,8 @@ class GcsStorageClient(
     override val size: Long
       get() = blob.size
 
-    override val createTime: Instant?
-      get() = blob.createTimeOffsetDateTime?.toInstant()
+    override val createTime: Instant
+      get() = checkNotNull(blob.createTimeOffsetDateTime).toInstant()
 
     override fun read(): Flow<ByteString> {
       return blob.reader().asFlow(READ_BUFFER_SIZE, blockingContext + CoroutineName("readBlob"))

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -204,6 +204,9 @@ class GcsStorageClient(
     override val size: Long
       get() = blob.size
 
+    override val createTime: Instant?
+      get() = blob.createTimeOffsetDateTime?.toInstant()
+
     override fun read(): Flow<ByteString> {
       return blob.reader().asFlow(READ_BUFFER_SIZE, blockingContext + CoroutineName("readBlob"))
     }

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -134,6 +134,30 @@ class GcsStorageClient(
       .flowOn(blockingContext + CoroutineName("listBlobs"))
   }
 
+  override suspend fun listBlobKeys(prefix: String, delimiter: String): Flow<String> {
+    val options =
+      arrayOf(
+        Storage.BlobListOption.prefix(prefix),
+        Storage.BlobListOption.delimiter(delimiter),
+      )
+
+    val blobPage: Page<Blob> =
+      try {
+        storage.list(bucketName, *options)
+      } catch (e: GcsStorageException) {
+        throw StorageException("Failed to list blob keys.", e)
+      }
+
+    return flow {
+        // When using a delimiter, the GCS API returns "prefix" entries for virtual directories.
+        // The Java client exposes these through Page.getValues() with names ending in the delimiter.
+        for (blob: Blob in blobPage.iterateAll()) {
+          emit(blob.name)
+        }
+      }
+      .flowOn(blockingContext + CoroutineName("listBlobKeys"))
+  }
+
   override suspend fun updateBlobMetadata(
     blobKey: String,
     customCreateTime: Instant?,

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -136,7 +136,10 @@ class GcsStorageClient(
 
   override suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
     val options =
-      arrayOf(Storage.BlobListOption.prefix(prefix), Storage.BlobListOption.delimiter(DELIMITER))
+      arrayOf(
+        Storage.BlobListOption.prefix(prefix),
+        Storage.BlobListOption.delimiter(StorageClient.DELIMITER),
+      )
 
     val blobPage: Page<Blob> =
       try {

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -149,12 +149,10 @@ class GcsStorageClient(
       }
 
     return flow {
-        // When using a delimiter, the GCS API returns both items and prefix entries.
-        // Only emit prefix entries (names ending with the delimiter), not direct items.
+        // When using a delimiter, the GCS API returns both items (direct blobs) and prefix
+        // entries (virtual directories ending with the delimiter).
         for (blob: Blob in blobPage.iterateAll()) {
-          if (blob.name.endsWith(delimiter)) {
-            emit(blob.name)
-          }
+          emit(blob.name)
         }
       }
       .flowOn(blockingContext + CoroutineName("listBlobKeys"))

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -134,9 +134,9 @@ class GcsStorageClient(
       .flowOn(blockingContext + CoroutineName("listBlobs"))
   }
 
-  override suspend fun listBlobKeys(prefix: String, delimiter: String): Flow<String> {
+  override suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
     val options =
-      arrayOf(Storage.BlobListOption.prefix(prefix), Storage.BlobListOption.delimiter(delimiter))
+      arrayOf(Storage.BlobListOption.prefix(prefix), Storage.BlobListOption.delimiter(DELIMITER))
 
     val blobPage: Page<Blob> =
       try {
@@ -152,7 +152,7 @@ class GcsStorageClient(
           emit(blob.name)
         }
       }
-      .flowOn(blockingContext + CoroutineName("listBlobKeys"))
+      .flowOn(blockingContext + CoroutineName("listDelimitedBlobKeys"))
   }
 
   override suspend fun updateBlobMetadata(

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -134,7 +134,7 @@ class GcsStorageClient(
       .flowOn(blockingContext + CoroutineName("listBlobs"))
   }
 
-  override suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
+  override suspend fun listBlobKeysAndPrefixes(prefix: String): Flow<String> {
     val options =
       arrayOf(
         Storage.BlobListOption.prefix(prefix),
@@ -155,7 +155,7 @@ class GcsStorageClient(
           emit(blob.name)
         }
       }
-      .flowOn(blockingContext + CoroutineName("listDelimitedBlobKeys"))
+      .flowOn(blockingContext + CoroutineName("listBlobKeysAndPrefixes"))
   }
 
   override suspend fun updateBlobMetadata(

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -207,6 +207,9 @@ class GcsStorageClient(
     override val createTime: Instant
       get() = checkNotNull(blob.createTimeOffsetDateTime).toInstant()
 
+    override val updateTime: Instant
+      get() = checkNotNull(blob.updateTimeOffsetDateTime).toInstant()
+
     override fun read(): Flow<ByteString> {
       return blob.reader().asFlow(READ_BUFFER_SIZE, blockingContext + CoroutineName("readBlob"))
     }

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -136,10 +136,7 @@ class GcsStorageClient(
 
   override suspend fun listBlobKeys(prefix: String, delimiter: String): Flow<String> {
     val options =
-      arrayOf(
-        Storage.BlobListOption.prefix(prefix),
-        Storage.BlobListOption.delimiter(delimiter),
-      )
+      arrayOf(Storage.BlobListOption.prefix(prefix), Storage.BlobListOption.delimiter(delimiter))
 
     val blobPage: Page<Blob> =
       try {

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -88,6 +88,9 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
     override val createTime: Instant
       get() = blob.createTime
 
+    override val updateTime: Instant
+      get() = blob.updateTime
+
     override val size: Long
       get() = blob.size
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.storage
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteStringUtf8
+import java.time.Instant
 import java.util.logging.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -83,6 +84,9 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
   private inner class Blob(private val blob: StorageClient.Blob, override val blobKey: String) :
     StorageClient.Blob {
     override val storageClient = this@MesosRecordIoStorageClient.storageClient
+
+    override val createTime: Instant?
+      get() = blob.createTime
 
     override val size: Long
       get() = blob.size

--- a/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClient.kt
@@ -85,7 +85,7 @@ class MesosRecordIoStorageClient(private val storageClient: StorageClient) : Sto
     StorageClient.Blob {
     override val storageClient = this@MesosRecordIoStorageClient.storageClient
 
-    override val createTime: Instant?
+    override val createTime: Instant
       get() = blob.createTime
 
     override val size: Long

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -46,13 +46,12 @@ interface StorageClient {
   suspend fun listBlobs(prefix: String? = null): Flow<Blob>
 
   /**
-   * Lists blob keys and unique key prefixes (virtual directories) directly under the given
-   * [prefix] using the specified [delimiter].
+   * Lists unique key prefixes (virtual directories) directly under the given [prefix] using the
+   * specified [delimiter].
    *
-   * This mirrors the behavior of GCS delimiter-based listing:
-   * - Blobs whose keys do not contain the [delimiter] after [prefix] are returned as-is.
-   * - Blobs whose keys contain the [delimiter] after [prefix] are grouped, and only the common
-   *   prefix up to and including the first [delimiter] is returned (deduplicated).
+   * Blobs whose keys contain the [delimiter] after [prefix] are grouped, and only the common
+   * prefix up to and including the first encountered [delimiter] is returned (deduplicated). Blobs
+   * without the [delimiter] after [prefix] are not included.
    *
    * For example, given blobs:
    * ```
@@ -61,28 +60,25 @@ interface StorageClient {
    *   path/2026-03-13/data
    *   path/2026-03-14/done
    * ```
-   * Calling `listBlobKeys("path/", "/")` returns
-   * `["path/2026-03-13/", "path/2026-03-14/", "path/file.txt"]`.
+   * Calling `listBlobKeys("path/", "/")` returns `["path/2026-03-13/", "path/2026-03-14/"]`.
    *
    * Implementations should use the storage backend's native prefix/delimiter support where
    * available (e.g., GCS delimiter listing) to avoid enumerating all objects.
    *
    * @param prefix The prefix to list under.
    * @param delimiter The delimiter used to define virtual directory boundaries.
-   * @return A [Flow] of blob keys and prefix strings.
+   * @return A [Flow] of prefix strings, each ending at the first encountered [delimiter].
    */
   suspend fun listBlobKeys(prefix: String, delimiter: String = "/"): Flow<String> {
-    val keys = mutableSetOf<String>()
+    val prefixes = mutableSetOf<String>()
     listBlobs(prefix).toList().forEach { blob ->
       val relativePath = blob.blobKey.removePrefix(prefix)
       val delimiterIndex = relativePath.indexOf(delimiter)
       if (delimiterIndex >= 0) {
-        keys.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
-      } else {
-        keys.add(blob.blobKey)
+        prefixes.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
       }
     }
-    return flow { keys.sorted().forEach { emit(it) } }
+    return flow { prefixes.sorted().forEach { emit(it) } }
   }
 
   /** Reference to a blob in a storage system. */

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -18,8 +18,8 @@ import com.google.protobuf.ByteString
 import java.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.storage.StorageClient.Blob
 
 /** Interface for blob/object storage operations. */
@@ -46,8 +46,8 @@ interface StorageClient {
   suspend fun listBlobs(prefix: String? = null): Flow<Blob>
 
   /**
-   * Lists blob keys and unique key prefixes (virtual directories) directly under the given
-   * [prefix] using the specified [delimiter].
+   * Lists blob keys and unique key prefixes (virtual directories) directly under the given [prefix]
+   * using the specified [delimiter].
    *
    * This mirrors the behavior of GCS delimiter-based listing:
    * - Blobs whose keys do not contain the [delimiter] after [prefix] are returned as-is.
@@ -61,8 +61,9 @@ interface StorageClient {
    *   path/2026-03-13/data
    *   path/2026-03-14/done
    * ```
-   * Calling `listBlobKeys("path/", "/")` returns
-   * `["path/2026-03-13/", "path/2026-03-14/", "path/file.txt"]`.
+   *
+   * Calling `listBlobKeys("path/", "/")` returns `["path/2026-03-13/", "path/2026-03-14/",
+   * "path/file.txt"]`.
    *
    * Implementations should use the storage backend's native prefix/delimiter support where
    * available (e.g., GCS delimiter listing) to avoid enumerating all objects.

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -47,12 +47,12 @@ interface StorageClient {
 
   /**
    * Lists blob keys and unique key prefixes (virtual directories) directly under the given [prefix]
-   * using the specified [delimiter].
+   * using [DELIMITER].
    *
    * This mirrors the behavior of GCS delimiter-based listing:
-   * - Blobs whose keys do not contain the [delimiter] after [prefix] are returned as-is.
-   * - Blobs whose keys contain the [delimiter] after [prefix] are grouped, and only the common
-   *   prefix up to and including the first encountered [delimiter] is returned (deduplicated).
+   * - Blobs whose keys do not contain the [DELIMITER] after [prefix] are returned as-is.
+   * - Blobs whose keys contain the [DELIMITER] after [prefix] are grouped, and only the common
+   *   prefix up to and including the first encountered [DELIMITER] is returned (deduplicated).
    *
    * For example, given blobs:
    * ```
@@ -62,28 +62,32 @@ interface StorageClient {
    *   path/2026-03-14/done
    * ```
    *
-   * Calling `listBlobKeys("path/", "/")` returns `["path/2026-03-13/", "path/2026-03-14/",
+   * Calling `listDelimitedBlobKeys("path/")` returns `["path/2026-03-13/", "path/2026-03-14/",
    * "path/file.txt"]`.
    *
    * Implementations should use the storage backend's native prefix/delimiter support where
    * available (e.g., GCS delimiter listing) to avoid enumerating all objects.
    *
    * @param prefix The prefix to list under.
-   * @param delimiter The delimiter used to define virtual directory boundaries.
-   * @return A [Flow] of blob keys and prefix strings ending at the first encountered [delimiter].
+   * @return A [Flow] of blob keys and prefix strings ending at the first encountered [DELIMITER].
    */
-  suspend fun listBlobKeys(prefix: String, delimiter: String = "/"): Flow<String> {
+  suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
     val keys = mutableSetOf<String>()
     listBlobs(prefix).toList().forEach { blob ->
       val relativePath = blob.blobKey.removePrefix(prefix)
-      val delimiterIndex = relativePath.indexOf(delimiter)
+      val delimiterIndex = relativePath.indexOf(DELIMITER)
       if (delimiterIndex >= 0) {
-        keys.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
+        keys.add(prefix + relativePath.substring(0, delimiterIndex + DELIMITER.length))
       } else {
         keys.add(blob.blobKey)
       }
     }
     return flow { keys.sorted().forEach { emit(it) } }
+  }
+
+  companion object {
+    /** Delimiter used by [listDelimitedBlobKeys] to define virtual directory boundaries. */
+    const val DELIMITER = "/"
   }
 
   /** Reference to a blob in a storage system. */

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -46,34 +46,43 @@ interface StorageClient {
   suspend fun listBlobs(prefix: String? = null): Flow<Blob>
 
   /**
-   * Lists unique key prefixes (virtual directories) under the given [prefix] using the specified
-   * [delimiter].
+   * Lists blob keys and unique key prefixes (virtual directories) directly under the given
+   * [prefix] using the specified [delimiter].
+   *
+   * This mirrors the behavior of GCS delimiter-based listing:
+   * - Blobs whose keys do not contain the [delimiter] after [prefix] are returned as-is.
+   * - Blobs whose keys contain the [delimiter] after [prefix] are grouped, and only the common
+   *   prefix up to and including the first [delimiter] is returned (deduplicated).
    *
    * For example, given blobs:
    * ```
+   *   path/file.txt
    *   path/2026-03-13/done
    *   path/2026-03-13/data
    *   path/2026-03-14/done
    * ```
-   * Calling `listBlobKeys("path/", "/")` returns `["path/2026-03-13/", "path/2026-03-14/"]`.
+   * Calling `listBlobKeys("path/", "/")` returns
+   * `["path/2026-03-13/", "path/2026-03-14/", "path/file.txt"]`.
    *
    * Implementations should use the storage backend's native prefix/delimiter support where
    * available (e.g., GCS delimiter listing) to avoid enumerating all objects.
    *
    * @param prefix The prefix to list under.
    * @param delimiter The delimiter used to define virtual directory boundaries.
-   * @return A [Flow] of prefix strings representing virtual directories.
+   * @return A [Flow] of blob keys and prefix strings.
    */
   suspend fun listBlobKeys(prefix: String, delimiter: String = "/"): Flow<String> {
-    val prefixes = mutableSetOf<String>()
+    val keys = mutableSetOf<String>()
     listBlobs(prefix).toList().forEach { blob ->
       val relativePath = blob.blobKey.removePrefix(prefix)
       val delimiterIndex = relativePath.indexOf(delimiter)
       if (delimiterIndex >= 0) {
-        prefixes.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
+        keys.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
+      } else {
+        keys.add(blob.blobKey)
       }
     }
-    return flow { prefixes.sorted().forEach { emit(it) } }
+    return flow { keys.sorted().forEach { emit(it) } }
   }
 
   /** Reference to a blob in a storage system. */

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -62,7 +62,7 @@ interface StorageClient {
    *   path/2026-03-14/done
    * ```
    *
-   * Calling `listDelimitedBlobKeys("path/")` returns `["path/2026-03-13/", "path/2026-03-14/",
+   * Calling `listBlobKeysAndPrefixes("path/")` returns `["path/2026-03-13/", "path/2026-03-14/",
    * "path/file.txt"]`.
    *
    * Implementations should use the storage backend's native prefix/delimiter support where
@@ -71,7 +71,7 @@ interface StorageClient {
    * @param prefix The prefix to list under.
    * @return A [Flow] of blob keys and prefix strings ending at the first encountered [DELIMITER].
    */
-  suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
+  suspend fun listBlobKeysAndPrefixes(prefix: String): Flow<String> {
     val keys = mutableSetOf<String>()
     listBlobs(prefix).toList().forEach { blob ->
       val relativePath = blob.blobKey.removePrefix(prefix)
@@ -86,7 +86,7 @@ interface StorageClient {
   }
 
   companion object {
-    /** Delimiter used by [listDelimitedBlobKeys] to define virtual directory boundaries. */
+    /** Delimiter used by [listBlobKeysAndPrefixes] to define virtual directory boundaries. */
     const val DELIMITER = "/"
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -17,6 +17,8 @@ package org.wfanet.measurement.storage
 import com.google.protobuf.ByteString
 import java.time.Instant
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.flowOf
 import org.wfanet.measurement.storage.StorageClient.Blob
 
@@ -42,6 +44,37 @@ interface StorageClient {
    *   filters out blobs with blob keys that do not match the prefix.
    */
   suspend fun listBlobs(prefix: String? = null): Flow<Blob>
+
+  /**
+   * Lists unique key prefixes (virtual directories) under the given [prefix] using the specified
+   * [delimiter].
+   *
+   * For example, given blobs:
+   * ```
+   *   path/2026-03-13/done
+   *   path/2026-03-13/data
+   *   path/2026-03-14/done
+   * ```
+   * Calling `listBlobKeys("path/", "/")` returns `["path/2026-03-13/", "path/2026-03-14/"]`.
+   *
+   * Implementations should use the storage backend's native prefix/delimiter support where
+   * available (e.g., GCS delimiter listing) to avoid enumerating all objects.
+   *
+   * @param prefix The prefix to list under.
+   * @param delimiter The delimiter used to define virtual directory boundaries.
+   * @return A [Flow] of prefix strings representing virtual directories.
+   */
+  suspend fun listBlobKeys(prefix: String, delimiter: String = "/"): Flow<String> {
+    val prefixes = mutableSetOf<String>()
+    listBlobs(prefix).toList().forEach { blob ->
+      val relativePath = blob.blobKey.removePrefix(prefix)
+      val delimiterIndex = relativePath.indexOf(delimiter)
+      if (delimiterIndex >= 0) {
+        prefixes.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
+      }
+    }
+    return flow { prefixes.sorted().forEach { emit(it) } }
+  }
 
   /** Reference to a blob in a storage system. */
   interface Blob {

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -105,6 +105,25 @@ interface StorageClient {
     }
   }
 
+  /**
+   * Lists blobs under [prefix] that were updated strictly after [after].
+   *
+   * Implementations should use native server-side filtering where available.
+   *
+   * @param prefix A blob key prefix to scope the listing.
+   * @param after Only blobs updated after this instant are returned.
+   * @return A [Flow] of [Blob]s updated after [after].
+   */
+  suspend fun listBlobsUpdatedAfter(prefix: String, after: Instant): Flow<Blob> {
+    return flow {
+      listBlobs(prefix).collect { blob ->
+        if (blob.updateTime.isAfter(after)) {
+          emit(blob)
+        }
+      }
+    }
+  }
+
   companion object {
     /** Delimiter used by [listBlobKeysAndPrefixes] to define virtual directory boundaries. */
     const val DELIMITER = "/"
@@ -123,6 +142,9 @@ interface StorageClient {
 
     /** The time the blob was created. */
     val createTime: Instant
+
+    /** The time the blob was last updated. */
+    val updateTime: Instant
 
     /** Returns a [Flow] for the blob content. */
     fun read(): Flow<ByteString>

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -46,12 +46,13 @@ interface StorageClient {
   suspend fun listBlobs(prefix: String? = null): Flow<Blob>
 
   /**
-   * Lists unique key prefixes (virtual directories) directly under the given [prefix] using the
-   * specified [delimiter].
+   * Lists blob keys and unique key prefixes (virtual directories) directly under the given
+   * [prefix] using the specified [delimiter].
    *
-   * Blobs whose keys contain the [delimiter] after [prefix] are grouped, and only the common
-   * prefix up to and including the first encountered [delimiter] is returned (deduplicated). Blobs
-   * without the [delimiter] after [prefix] are not included.
+   * This mirrors the behavior of GCS delimiter-based listing:
+   * - Blobs whose keys do not contain the [delimiter] after [prefix] are returned as-is.
+   * - Blobs whose keys contain the [delimiter] after [prefix] are grouped, and only the common
+   *   prefix up to and including the first encountered [delimiter] is returned (deduplicated).
    *
    * For example, given blobs:
    * ```
@@ -60,25 +61,28 @@ interface StorageClient {
    *   path/2026-03-13/data
    *   path/2026-03-14/done
    * ```
-   * Calling `listBlobKeys("path/", "/")` returns `["path/2026-03-13/", "path/2026-03-14/"]`.
+   * Calling `listBlobKeys("path/", "/")` returns
+   * `["path/2026-03-13/", "path/2026-03-14/", "path/file.txt"]`.
    *
    * Implementations should use the storage backend's native prefix/delimiter support where
    * available (e.g., GCS delimiter listing) to avoid enumerating all objects.
    *
    * @param prefix The prefix to list under.
    * @param delimiter The delimiter used to define virtual directory boundaries.
-   * @return A [Flow] of prefix strings, each ending at the first encountered [delimiter].
+   * @return A [Flow] of blob keys and prefix strings ending at the first encountered [delimiter].
    */
   suspend fun listBlobKeys(prefix: String, delimiter: String = "/"): Flow<String> {
-    val prefixes = mutableSetOf<String>()
+    val keys = mutableSetOf<String>()
     listBlobs(prefix).toList().forEach { blob ->
       val relativePath = blob.blobKey.removePrefix(prefix)
       val delimiterIndex = relativePath.indexOf(delimiter)
       if (delimiterIndex >= 0) {
-        prefixes.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
+        keys.add(prefix + relativePath.substring(0, delimiterIndex + delimiter.length))
+      } else {
+        keys.add(blob.blobKey)
       }
     }
-    return flow { prefixes.sorted().forEach { emit(it) } }
+    return flow { keys.sorted().forEach { emit(it) } }
   }
 
   /** Reference to a blob in a storage system. */

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -89,8 +89,7 @@ interface StorageClient {
    * Lists blobs under [prefix] that were created strictly after [after].
    *
    * Implementations should use native server-side filtering where available (e.g., GCS
-   * `timeCreatedAfter`). If the implementation does not support [Blob.createTime], an empty flow is
-   * returned.
+   * `timeCreatedAfter`).
    *
    * @param prefix A blob key prefix to scope the listing.
    * @param after Only blobs created after this instant are returned.
@@ -99,8 +98,7 @@ interface StorageClient {
   suspend fun listBlobsCreatedAfter(prefix: String, after: Instant): Flow<Blob> {
     return flow {
       listBlobs(prefix).collect { blob ->
-        val blobTime = blob.createTime
-        if (blobTime != null && blobTime.isAfter(after)) {
+        if (blob.createTime.isAfter(after)) {
           emit(blob)
         }
       }
@@ -123,8 +121,8 @@ interface StorageClient {
     /** Size of the blob in bytes. */
     val size: Long
 
-    /** The time the blob was created. May be `null` if the storage backend does not support it. */
-    val createTime: Instant?
+    /** The time the blob was created. */
+    val createTime: Instant
 
     /** Returns a [Flow] for the blob content. */
     fun read(): Flow<ByteString>

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -85,6 +85,28 @@ interface StorageClient {
     return flow { keys.sorted().forEach { emit(it) } }
   }
 
+  /**
+   * Lists blobs under [prefix] that were created strictly after [after].
+   *
+   * Implementations should use native server-side filtering where available (e.g., GCS
+   * `timeCreatedAfter`). If the implementation does not support [Blob.createTime], an empty flow is
+   * returned.
+   *
+   * @param prefix A blob key prefix to scope the listing.
+   * @param after Only blobs created after this instant are returned.
+   * @return A [Flow] of [Blob]s created after [after].
+   */
+  suspend fun listBlobsCreatedAfter(prefix: String, after: Instant): Flow<Blob> {
+    return flow {
+      listBlobs(prefix).collect { blob ->
+        val blobTime = blob.createTime
+        if (blobTime != null && blobTime.isAfter(after)) {
+          emit(blob)
+        }
+      }
+    }
+  }
+
   companion object {
     /** Delimiter used by [listBlobKeysAndPrefixes] to define virtual directory boundaries. */
     const val DELIMITER = "/"
@@ -95,10 +117,14 @@ interface StorageClient {
     /** The [StorageClient] from which this [Blob] was obtained. */
     val storageClient: StorageClient
 
+    /** The key identifying this blob. */
     val blobKey: String
 
     /** Size of the blob in bytes. */
     val size: Long
+
+    /** The time the blob was created. May be `null` if the storage backend does not support it. */
+    val createTime: Instant?
 
     /** Returns a [Flow] for the blob content. */
     fun read(): Flow<ByteString>

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -115,6 +115,31 @@ class FileSystemStorageClient(
       .flowOn(coroutineContext)
   }
 
+  override suspend fun listBlobKeys(prefix: String, delimiter: String): Flow<String> {
+    require(delimiter == "/") { "FileSystemStorageClient only supports '/' delimiter" }
+
+    val prefixDir =
+      if (prefix.isEmpty()) {
+        directory
+      } else {
+        File(directory, prefix.trimEnd('/'))
+      }
+
+    if (!prefixDir.isDirectory) {
+      return emptyFlow()
+    }
+
+    return channelFlow<String> {
+        withContext(coroutineContext) {
+          prefixDir.listFiles()?.filter { it.isDirectory }?.forEach { dir ->
+            val relativePath = dir.toPath().relativeTo(directory.toPath()).toBlobKey()
+            trySendBlocking("$relativePath/")
+          }
+        }
+      }
+      .flowOn(coroutineContext)
+  }
+
   private fun resolvePath(blobKey: String): File {
     val relativePath =
       if (File.separatorChar == '/') {

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -131,13 +131,9 @@ class FileSystemStorageClient(
 
     return channelFlow<String> {
         withContext(coroutineContext) {
-          prefixDir.listFiles()?.forEach { entry ->
-            val relativePath = entry.toPath().relativeTo(directory.toPath()).toBlobKey()
-            if (entry.isDirectory) {
-              trySendBlocking("$relativePath/")
-            } else {
-              trySendBlocking(relativePath)
-            }
+          prefixDir.listFiles()?.filter { it.isDirectory }?.forEach { dir ->
+            val relativePath = dir.toPath().relativeTo(directory.toPath()).toBlobKey()
+            trySendBlocking("$relativePath/")
           }
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -176,6 +176,9 @@ class FileSystemStorageClient(
           .creationTime()
           .toInstant()
 
+    override val updateTime: Instant
+      get() = Instant.ofEpochMilli(file.lastModified())
+
     override fun read(): Flow<ByteString> {
       return file
         .inputStream()

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -170,8 +170,14 @@ class FileSystemStorageClient(
     override val size: Long
       get() = file.length()
 
-    override val createTime: Instant?
-      get() = Instant.ofEpochMilli(file.lastModified())
+    override val createTime: Instant
+      get() =
+        java.nio.file.Files.readAttributes(
+            file.toPath(),
+            java.nio.file.attribute.BasicFileAttributes::class.java,
+          )
+          .creationTime()
+          .toInstant()
 
     override fun read(): Flow<ByteString> {
       return file

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -131,9 +131,13 @@ class FileSystemStorageClient(
 
     return channelFlow<String> {
         withContext(coroutineContext) {
-          prefixDir.listFiles()?.filter { it.isDirectory }?.forEach { dir ->
-            val relativePath = dir.toPath().relativeTo(directory.toPath()).toBlobKey()
-            trySendBlocking("$relativePath/")
+          prefixDir.listFiles()?.forEach { entry ->
+            val relativePath = entry.toPath().relativeTo(directory.toPath()).toBlobKey()
+            if (entry.isDirectory) {
+              trySendBlocking("$relativePath/")
+            } else {
+              trySendBlocking(relativePath)
+            }
           }
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -22,6 +22,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.time.Instant
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.relativeTo
 import kotlinx.coroutines.CoroutineName
@@ -168,6 +169,9 @@ class FileSystemStorageClient(
 
     override val size: Long
       get() = file.length()
+
+    override val createTime: Instant?
+      get() = Instant.ofEpochMilli(file.lastModified())
 
     override fun read(): Flow<ByteString> {
       return file

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -115,8 +115,7 @@ class FileSystemStorageClient(
       .flowOn(coroutineContext)
   }
 
-  override suspend fun listBlobKeys(prefix: String, delimiter: String): Flow<String> {
-    require(delimiter == "/") { "FileSystemStorageClient only supports '/' delimiter" }
+  override suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
 
     val prefixDir =
       if (prefix.isEmpty()) {

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -172,10 +172,7 @@ class FileSystemStorageClient(
 
     override val createTime: Instant
       get() =
-        java.nio.file.Files.readAttributes(
-            file.toPath(),
-            java.nio.file.attribute.BasicFileAttributes::class.java,
-          )
+        Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
           .creationTime()
           .toInstant()
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageClient.kt
@@ -115,7 +115,7 @@ class FileSystemStorageClient(
       .flowOn(coroutineContext)
   }
 
-  override suspend fun listDelimitedBlobKeys(prefix: String): Flow<String> {
+  override suspend fun listBlobKeysAndPrefixes(prefix: String): Flow<String> {
 
     val prefixDir =
       if (prefix.isEmpty()) {

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
@@ -64,6 +64,7 @@ class FileSystemStorageService(
     return blobMetadata {
       size = blob.size
       createTime = blob.createTime.toProtoTime()
+      updateTime = blob.updateTime.toProtoTime()
     }
   }
 
@@ -73,6 +74,7 @@ class FileSystemStorageService(
       size = blob.size
       blobKey = request.blobKey
       createTime = blob.createTime.toProtoTime()
+      updateTime = blob.updateTime.toProtoTime()
     }
   }
 
@@ -94,6 +96,7 @@ class FileSystemStorageService(
           blobKey = it.blobKey
           size = it.size
           createTime = it.createTime.toProtoTime()
+          updateTime = it.updateTime.toProtoTime()
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
@@ -63,9 +63,7 @@ class FileSystemStorageService(
 
     return blobMetadata {
       size = blob.size
-      if (blob.createTime != null) {
-        createTime = blob.createTime!!.toProtoTime()
-      }
+      createTime = blob.createTime.toProtoTime()
     }
   }
 
@@ -74,9 +72,7 @@ class FileSystemStorageService(
     return blobMetadata {
       size = blob.size
       blobKey = request.blobKey
-      if (blob.createTime != null) {
-        createTime = blob.createTime!!.toProtoTime()
-      }
+      createTime = blob.createTime.toProtoTime()
     }
   }
 
@@ -97,9 +93,7 @@ class FileSystemStorageService(
         blobMetadata += blobMetadata {
           blobKey = it.blobKey
           size = it.size
-          if (it.createTime != null) {
-            createTime = it.createTime!!.toProtoTime()
-          }
+          createTime = it.createTime.toProtoTime()
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageService.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import org.jetbrains.annotations.BlockingExecutor
 import org.wfanet.measurement.common.consumeFirstOr
+import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.testing.BlobMetadata
 import org.wfanet.measurement.internal.testing.DeleteBlobRequest
 import org.wfanet.measurement.internal.testing.DeleteBlobResponse
@@ -60,13 +61,22 @@ class FileSystemStorageService(
           storageClient.writeBlob(blobKey, content)
         }
 
-    return BlobMetadata.newBuilder().setSize(blob.size).build()
+    return blobMetadata {
+      size = blob.size
+      if (blob.createTime != null) {
+        createTime = blob.createTime!!.toProtoTime()
+      }
+    }
   }
 
   override suspend fun getBlobMetadata(request: GetBlobMetadataRequest): BlobMetadata {
+    val blob = getBlob(request.blobKey)
     return blobMetadata {
-      size = getBlob(request.blobKey).size
+      size = blob.size
       blobKey = request.blobKey
+      if (blob.createTime != null) {
+        createTime = blob.createTime!!.toProtoTime()
+      }
     }
   }
 
@@ -87,6 +97,9 @@ class FileSystemStorageService(
         blobMetadata += blobMetadata {
           blobKey = it.blobKey
           size = it.size
+          if (it.createTime != null) {
+            createTime = it.createTime!!.toProtoTime()
+          }
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
@@ -17,11 +17,13 @@ package org.wfanet.measurement.storage.forwarded
 import com.google.protobuf.ByteString
 import io.grpc.Status
 import io.grpc.StatusException
+import java.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import org.wfanet.measurement.common.asBufferedFlow
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.testing.ForwardedStorageGrpcKt.ForwardedStorageCoroutineStub
 import org.wfanet.measurement.internal.testing.WriteBlobRequest
 import org.wfanet.measurement.internal.testing.deleteBlobRequest
@@ -53,14 +55,18 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
     val metadata = storageStub.writeBlob(requests)
 
-    return Blob(blobKey, metadata.size)
+    return Blob(
+      blobKey,
+      metadata.size,
+      if (metadata.hasCreateTime()) metadata.createTime.toInstant() else null,
+    )
   }
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
     // Check if the blob exists
-    val blobSize =
+    val metadata =
       try {
-        storageStub.getBlobMetadata(getBlobMetadataRequest { this.blobKey = blobKey }).size
+        storageStub.getBlobMetadata(getBlobMetadataRequest { this.blobKey = blobKey })
       } catch (e: StatusException) {
         if (e.status.code == Status.NOT_FOUND.code) {
           return null
@@ -69,7 +75,11 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
       }
 
-    return Blob(blobKey, blobSize)
+    return Blob(
+      blobKey,
+      metadata.size,
+      if (metadata.hasCreateTime()) metadata.createTime.toInstant() else null,
+    )
   }
 
   override suspend fun listBlobs(prefix: String?): Flow<StorageClient.Blob> {
@@ -82,15 +92,20 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
       )
 
-    return listBlobMetadataResponse.blobMetadataList.map { Blob(it.blobKey, it.size) }.asFlow()
+    return listBlobMetadataResponse.blobMetadataList
+      .map {
+        Blob(it.blobKey, it.size, if (it.hasCreateTime()) it.createTime.toInstant() else null)
+      }
+      .asFlow()
   }
 
-  private inner class Blob(override val blobKey: String, override val size: Long) :
-    StorageClient.Blob {
+  private inner class Blob(
+    override val blobKey: String,
+    override val size: Long,
+    override val createTime: Instant?,
+  ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@ForwardedStorageClient
-
-    override val createTime: java.time.Instant? = null
 
     override fun read(): Flow<ByteString> {
       return storageStub.readBlob(readBlobRequest { blobKey = this@Blob.blobKey }).map { it.chunk }

--- a/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
@@ -55,7 +55,12 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
     val metadata = storageStub.writeBlob(requests)
 
-    return Blob(blobKey, metadata.size, metadata.createTime.toInstant())
+    return Blob(
+      blobKey,
+      metadata.size,
+      metadata.createTime.toInstant(),
+      metadata.updateTime.toInstant(),
+    )
   }
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
@@ -71,7 +76,12 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
       }
 
-    return Blob(blobKey, metadata.size, metadata.createTime.toInstant())
+    return Blob(
+      blobKey,
+      metadata.size,
+      metadata.createTime.toInstant(),
+      metadata.updateTime.toInstant(),
+    )
   }
 
   override suspend fun listBlobs(prefix: String?): Flow<StorageClient.Blob> {
@@ -85,7 +95,7 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
       )
 
     return listBlobMetadataResponse.blobMetadataList
-      .map { Blob(it.blobKey, it.size, it.createTime.toInstant()) }
+      .map { Blob(it.blobKey, it.size, it.createTime.toInstant(), it.updateTime.toInstant()) }
       .asFlow()
   }
 
@@ -93,6 +103,7 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
     override val blobKey: String,
     override val size: Long,
     override val createTime: Instant,
+    override val updateTime: Instant,
   ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@ForwardedStorageClient

--- a/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
@@ -55,11 +55,7 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
     val metadata = storageStub.writeBlob(requests)
 
-    return Blob(
-      blobKey,
-      metadata.size,
-      if (metadata.hasCreateTime()) metadata.createTime.toInstant() else null,
-    )
+    return Blob(blobKey, metadata.size, metadata.createTime.toInstant())
   }
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
@@ -75,11 +71,7 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
         }
       }
 
-    return Blob(
-      blobKey,
-      metadata.size,
-      if (metadata.hasCreateTime()) metadata.createTime.toInstant() else null,
-    )
+    return Blob(blobKey, metadata.size, metadata.createTime.toInstant())
   }
 
   override suspend fun listBlobs(prefix: String?): Flow<StorageClient.Blob> {
@@ -93,16 +85,14 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
       )
 
     return listBlobMetadataResponse.blobMetadataList
-      .map {
-        Blob(it.blobKey, it.size, if (it.hasCreateTime()) it.createTime.toInstant() else null)
-      }
+      .map { Blob(it.blobKey, it.size, it.createTime.toInstant()) }
       .asFlow()
   }
 
   private inner class Blob(
     override val blobKey: String,
     override val size: Long,
-    override val createTime: Instant?,
+    override val createTime: Instant,
   ) : StorageClient.Blob {
     override val storageClient: StorageClient
       get() = this@ForwardedStorageClient

--- a/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/forwarded/ForwardedStorageClient.kt
@@ -90,6 +90,8 @@ class ForwardedStorageClient(private val storageStub: ForwardedStorageCoroutineS
     override val storageClient: StorageClient
       get() = this@ForwardedStorageClient
 
+    override val createTime: java.time.Instant? = null
+
     override fun read(): Flow<ByteString> {
       return storageStub.readBlob(readBlobRequest { blobKey = this@Blob.blobKey }).map { it.chunk }
     }

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -166,6 +166,27 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
     assertThat(prefixes).containsExactly("a/b/")
   }
 
+  @Test
+  fun `listBlobKeys returns both direct files and directory prefixes`(): Unit = runBlocking {
+    // Files directly at the prefix level
+    storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
+    // Files inside subdirectories
+    storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
+
+    val keys = storageClient.listBlobKeys("path/", "/").toList()
+
+    // Should return direct files and directory prefixes, but NOT nested files
+    assertThat(keys).containsExactly(
+      "path/dir1/",
+      "path/dir2/",
+      "path/file1.txt",
+      "path/file2.txt",
+    )
+  }
+
   private fun prepareStorage() {
     runBlocking {
       storageClient.writeBlob(BLOB_KEY_1, "content1".toByteStringUtf8())

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -167,24 +167,25 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
   }
 
   @Test
-  fun `listBlobKeys excludes direct files and only returns directory prefixes`(): Unit =
-    runBlocking {
-      // Files directly at the prefix level (should NOT be returned)
-      storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
-      storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
-      // Files inside subdirectories (should be grouped into directory prefixes)
-      storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
-      storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
-      storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
+  fun `listBlobKeys returns both direct files and directory prefixes`(): Unit = runBlocking {
+    // Files directly at the prefix level
+    storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
+    // Files inside subdirectories
+    storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
 
-      val keys = storageClient.listBlobKeys("path/", "/").toList()
+    val keys = storageClient.listBlobKeys("path/", "/").toList()
 
-      // Should only return directory prefixes, not direct files or nested files
-      assertThat(keys).containsExactly(
-        "path/dir1/",
-        "path/dir2/",
-      )
-    }
+    // Should return direct files and directory prefixes, but NOT nested files
+    assertThat(keys).containsExactly(
+      "path/dir1/",
+      "path/dir2/",
+      "path/file1.txt",
+      "path/file2.txt",
+    )
+  }
 
   private fun prepareStorage() {
     runBlocking {

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -230,6 +230,73 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
     assertThat(blobs).isEmpty()
   }
 
+  @Test
+  fun `Blob updateTime is not null after writing`() = runBlocking {
+    val blobKey = "blob-with-update-time"
+    val blob = storageClient.writeBlob(blobKey, testBlobContent)
+
+    assertThat(blob.updateTime).isNotNull()
+  }
+
+  @Test
+  fun `getBlob returns blob with updateTime`() = runBlocking {
+    val blobKey = "blob-get-update-time"
+    storageClient.writeBlob(blobKey, testBlobContent)
+
+    val blob = assertNotNull(storageClient.getBlob(blobKey))
+
+    assertThat(blob.updateTime).isNotNull()
+  }
+
+  @Test
+  fun `listBlobsUpdatedAfter returns blobs updated after the given instant`(): Unit = runBlocking {
+    val beforeWrite = Instant.now().minusSeconds(1)
+    storageClient.writeBlob("update-prefix/blob1", "content1".toByteStringUtf8())
+    storageClient.writeBlob("update-prefix/blob2", "content2".toByteStringUtf8())
+
+    val blobs = storageClient.listBlobsUpdatedAfter("update-prefix/", beforeWrite).toList()
+
+    assertThat(blobs).hasSize(2)
+    val blobKeys = blobs.map { it.blobKey }.toSet()
+    assertThat(blobKeys).containsExactly("update-prefix/blob1", "update-prefix/blob2")
+  }
+
+  @Test
+  fun `listBlobsUpdatedAfter returns empty flow when no blobs match`(): Unit = runBlocking {
+    storageClient.writeBlob("old-update-prefix/blob1", "content1".toByteStringUtf8())
+
+    val futureInstant = Instant.now().plusSeconds(3600)
+    val blobs = storageClient.listBlobsUpdatedAfter("old-update-prefix/", futureInstant).toList()
+
+    assertThat(blobs).isEmpty()
+  }
+
+  @Test
+  fun `listBlobsUpdatedAfter returns empty flow for non-existent prefix`(): Unit = runBlocking {
+    val blobs =
+      storageClient.listBlobsUpdatedAfter("non-existent/", Instant.now().minusSeconds(1)).toList()
+
+    assertThat(blobs).isEmpty()
+  }
+
+  @Test
+  fun `writeBlob overwrite updates updateTime`() = runBlocking {
+    val blobKey = "blob-overwrite-update-time"
+    val firstBlob = storageClient.writeBlob(blobKey, "initial content".toByteStringUtf8())
+    val firstUpdateTime = firstBlob.updateTime
+
+    // Small delay to ensure time difference is measurable.
+    Thread.sleep(1100)
+
+    val overwrittenBlob = storageClient.writeBlob(blobKey, "updated content".toByteStringUtf8())
+
+    // updateTime should reflect the most recent write.
+    // Note: We cannot verify that createTime is preserved across overwrites because some storage
+    // clients (e.g. S3 without versioning) do not track a true creation time separately
+    // from the last modified time.
+    assertThat(overwrittenBlob.updateTime).isGreaterThan(firstUpdateTime)
+  }
+
   private fun prepareStorage() {
     runBlocking {
       storageClient.writeBlob(BLOB_KEY_1, "content1".toByteStringUtf8())

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -24,7 +24,6 @@ import kotlin.test.assertNotNull
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.wfanet.measurement.common.BYTES_PER_MIB
 import org.wfanet.measurement.common.size
@@ -35,8 +34,6 @@ import org.wfanet.measurement.storage.testing.BlobSubject.Companion.assertThat
 abstract class AbstractStorageClientTest<T : StorageClient> {
   protected val testBlobContent: ByteString
     get() = Companion.testBlobContent
-
-  open val supportsCreateTime: Boolean = true
 
   open fun computeStoredBlobSize(content: ByteString, blobKey: String): Int {
     return content.size
@@ -186,7 +183,6 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `Blob createTime is not null after writing`() = runBlocking {
-    assumeTrue(supportsCreateTime)
     val blobKey = "blob-with-create-time"
     val blob = storageClient.writeBlob(blobKey, testBlobContent)
 
@@ -195,7 +191,6 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `getBlob returns blob with createTime`() = runBlocking {
-    assumeTrue(supportsCreateTime)
     val blobKey = "blob-get-create-time"
     storageClient.writeBlob(blobKey, testBlobContent)
 
@@ -206,7 +201,6 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `listBlobsCreatedAfter returns blobs created after the given instant`(): Unit = runBlocking {
-    assumeTrue(supportsCreateTime)
     val beforeWrite = Instant.now().minusSeconds(1)
     storageClient.writeBlob("time-prefix/blob1", "content1".toByteStringUtf8())
     storageClient.writeBlob("time-prefix/blob2", "content2".toByteStringUtf8())
@@ -220,7 +214,6 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `listBlobsCreatedAfter returns empty flow when no blobs match`(): Unit = runBlocking {
-    assumeTrue(supportsCreateTime)
     storageClient.writeBlob("old-prefix/blob1", "content1".toByteStringUtf8())
 
     val futureInstant = Instant.now().plusSeconds(3600)
@@ -231,7 +224,6 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `listBlobsCreatedAfter returns empty flow for non-existent prefix`(): Unit = runBlocking {
-    assumeTrue(supportsCreateTime)
     val blobs =
       storageClient.listBlobsCreatedAfter("non-existent/", Instant.now().minusSeconds(1)).toList()
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -18,6 +18,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import com.google.protobuf.kotlin.toByteStringUtf8
+import java.time.Instant
 import kotlin.random.Random
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.flow.emptyFlow
@@ -179,6 +180,55 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
       assertThat(keys)
         .containsExactly("path/dir1/", "path/dir2/", "path/file1.txt", "path/file2.txt")
     }
+
+  @Test
+  fun `Blob createTime is not null after writing`() = runBlocking {
+    val blobKey = "blob-with-create-time"
+    val blob = storageClient.writeBlob(blobKey, testBlobContent)
+
+    assertThat(blob.createTime).isNotNull()
+  }
+
+  @Test
+  fun `getBlob returns blob with createTime`() = runBlocking {
+    val blobKey = "blob-get-create-time"
+    storageClient.writeBlob(blobKey, testBlobContent)
+
+    val blob = assertNotNull(storageClient.getBlob(blobKey))
+
+    assertThat(blob.createTime).isNotNull()
+  }
+
+  @Test
+  fun `listBlobsCreatedAfter returns blobs created after the given instant`(): Unit = runBlocking {
+    val beforeWrite = Instant.now().minusSeconds(1)
+    storageClient.writeBlob("time-prefix/blob1", "content1".toByteStringUtf8())
+    storageClient.writeBlob("time-prefix/blob2", "content2".toByteStringUtf8())
+
+    val blobs = storageClient.listBlobsCreatedAfter("time-prefix/", beforeWrite).toList()
+
+    assertThat(blobs).hasSize(2)
+    val blobKeys = blobs.map { it.blobKey }.toSet()
+    assertThat(blobKeys).containsExactly("time-prefix/blob1", "time-prefix/blob2")
+  }
+
+  @Test
+  fun `listBlobsCreatedAfter returns empty flow when no blobs match`(): Unit = runBlocking {
+    storageClient.writeBlob("old-prefix/blob1", "content1".toByteStringUtf8())
+
+    val futureInstant = Instant.now().plusSeconds(3600)
+    val blobs = storageClient.listBlobsCreatedAfter("old-prefix/", futureInstant).toList()
+
+    assertThat(blobs).isEmpty()
+  }
+
+  @Test
+  fun `listBlobsCreatedAfter returns empty flow for non-existent prefix`(): Unit = runBlocking {
+    val blobs =
+      storageClient.listBlobsCreatedAfter("non-existent/", Instant.now().minusSeconds(1)).toList()
+
+    assertThat(blobs).isEmpty()
+  }
 
   private fun prepareStorage() {
     runBlocking {

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -142,11 +142,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
     val prefixes = storageClient.listBlobKeys("path/", "/").toList()
 
-    assertThat(prefixes).containsExactly(
-      "path/2026-03-13/",
-      "path/2026-03-14/",
-      "path/2026-03-15/",
-    )
+    assertThat(prefixes).containsExactly("path/2026-03-13/", "path/2026-03-14/", "path/2026-03-15/")
   }
 
   @Test
@@ -179,12 +175,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
     val keys = storageClient.listBlobKeys("path/", "/").toList()
 
     // Should return direct files and directory prefixes, but NOT nested files
-    assertThat(keys).containsExactly(
-      "path/dir1/",
-      "path/dir2/",
-      "path/file1.txt",
-      "path/file2.txt",
-    )
+    assertThat(keys).containsExactly("path/dir1/", "path/dir2/", "path/file1.txt", "path/file2.txt")
   }
 
   private fun prepareStorage() {

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -133,50 +133,52 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
   }
 
   @Test
-  fun `listBlobKeys returns unique prefixes for given delimiter`(): Unit = runBlocking {
+  fun `listDelimitedBlobKeys returns unique prefixes for given delimiter`(): Unit = runBlocking {
     storageClient.writeBlob("path/2026-03-13/done", "done".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-13/data1", "data".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-13/data2", "data".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-14/done", "done".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-15/done", "done".toByteStringUtf8())
 
-    val prefixes = storageClient.listBlobKeys("path/", "/").toList()
+    val prefixes = storageClient.listDelimitedBlobKeys("path/").toList()
 
     assertThat(prefixes).containsExactly("path/2026-03-13/", "path/2026-03-14/", "path/2026-03-15/")
   }
 
   @Test
-  fun `listBlobKeys returns empty flow for non-existent prefix`(): Unit = runBlocking {
-    val prefixes = storageClient.listBlobKeys("non-existent/", "/").toList()
+  fun `listDelimitedBlobKeys returns empty flow for non-existent prefix`(): Unit = runBlocking {
+    val prefixes = storageClient.listDelimitedBlobKeys("non-existent/").toList()
     assertThat(prefixes).isEmpty()
   }
 
   @Test
-  fun `listBlobKeys does not return nested prefixes`(): Unit = runBlocking {
+  fun `listDelimitedBlobKeys does not return nested prefixes`(): Unit = runBlocking {
     storageClient.writeBlob("a/b/c/file1", "data".toByteStringUtf8())
     storageClient.writeBlob("a/b/d/file2", "data".toByteStringUtf8())
 
-    val prefixes = storageClient.listBlobKeys("a/", "/").toList()
+    val prefixes = storageClient.listDelimitedBlobKeys("a/").toList()
 
     // Should only return the immediate child prefix, not nested ones
     assertThat(prefixes).containsExactly("a/b/")
   }
 
   @Test
-  fun `listBlobKeys returns both direct files and directory prefixes`(): Unit = runBlocking {
-    // Files directly at the prefix level
-    storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
-    storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
-    // Files inside subdirectories
-    storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
-    storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
-    storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
+  fun `listDelimitedBlobKeys returns both direct files and directory prefixes`(): Unit =
+    runBlocking {
+      // Files directly at the prefix level
+      storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
+      storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
+      // Files inside subdirectories
+      storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
+      storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
+      storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
 
-    val keys = storageClient.listBlobKeys("path/", "/").toList()
+      val keys = storageClient.listDelimitedBlobKeys("path/").toList()
 
-    // Should return direct files and directory prefixes, but NOT nested files
-    assertThat(keys).containsExactly("path/dir1/", "path/dir2/", "path/file1.txt", "path/file2.txt")
-  }
+      // Should return direct files and directory prefixes, but NOT nested files
+      assertThat(keys)
+        .containsExactly("path/dir1/", "path/dir2/", "path/file1.txt", "path/file2.txt")
+    }
 
   private fun prepareStorage() {
     runBlocking {

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertNotNull
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.wfanet.measurement.common.BYTES_PER_MIB
 import org.wfanet.measurement.common.size
@@ -34,6 +35,8 @@ import org.wfanet.measurement.storage.testing.BlobSubject.Companion.assertThat
 abstract class AbstractStorageClientTest<T : StorageClient> {
   protected val testBlobContent: ByteString
     get() = Companion.testBlobContent
+
+  open val supportsCreateTime: Boolean = true
 
   open fun computeStoredBlobSize(content: ByteString, blobKey: String): Int {
     return content.size
@@ -183,6 +186,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `Blob createTime is not null after writing`() = runBlocking {
+    assumeTrue(supportsCreateTime)
     val blobKey = "blob-with-create-time"
     val blob = storageClient.writeBlob(blobKey, testBlobContent)
 
@@ -191,6 +195,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `getBlob returns blob with createTime`() = runBlocking {
+    assumeTrue(supportsCreateTime)
     val blobKey = "blob-get-create-time"
     storageClient.writeBlob(blobKey, testBlobContent)
 
@@ -201,6 +206,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `listBlobsCreatedAfter returns blobs created after the given instant`(): Unit = runBlocking {
+    assumeTrue(supportsCreateTime)
     val beforeWrite = Instant.now().minusSeconds(1)
     storageClient.writeBlob("time-prefix/blob1", "content1".toByteStringUtf8())
     storageClient.writeBlob("time-prefix/blob2", "content2".toByteStringUtf8())
@@ -214,6 +220,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `listBlobsCreatedAfter returns empty flow when no blobs match`(): Unit = runBlocking {
+    assumeTrue(supportsCreateTime)
     storageClient.writeBlob("old-prefix/blob1", "content1".toByteStringUtf8())
 
     val futureInstant = Instant.now().plusSeconds(3600)
@@ -224,6 +231,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
 
   @Test
   fun `listBlobsCreatedAfter returns empty flow for non-existent prefix`(): Unit = runBlocking {
+    assumeTrue(supportsCreateTime)
     val blobs =
       storageClient.listBlobsCreatedAfter("non-existent/", Instant.now().minusSeconds(1)).toList()
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -132,6 +132,40 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
     assertThat(blobs).hasSize(3)
   }
 
+  @Test
+  fun `listBlobKeys returns unique prefixes for given delimiter`(): Unit = runBlocking {
+    storageClient.writeBlob("path/2026-03-13/done", "done".toByteStringUtf8())
+    storageClient.writeBlob("path/2026-03-13/data1", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/2026-03-13/data2", "data".toByteStringUtf8())
+    storageClient.writeBlob("path/2026-03-14/done", "done".toByteStringUtf8())
+    storageClient.writeBlob("path/2026-03-15/done", "done".toByteStringUtf8())
+
+    val prefixes = storageClient.listBlobKeys("path/", "/").toList()
+
+    assertThat(prefixes).containsExactly(
+      "path/2026-03-13/",
+      "path/2026-03-14/",
+      "path/2026-03-15/",
+    )
+  }
+
+  @Test
+  fun `listBlobKeys returns empty flow for non-existent prefix`(): Unit = runBlocking {
+    val prefixes = storageClient.listBlobKeys("non-existent/", "/").toList()
+    assertThat(prefixes).isEmpty()
+  }
+
+  @Test
+  fun `listBlobKeys does not return nested prefixes`(): Unit = runBlocking {
+    storageClient.writeBlob("a/b/c/file1", "data".toByteStringUtf8())
+    storageClient.writeBlob("a/b/d/file2", "data".toByteStringUtf8())
+
+    val prefixes = storageClient.listBlobKeys("a/", "/").toList()
+
+    // Should only return the immediate child prefix, not nested ones
+    assertThat(prefixes).containsExactly("a/b/")
+  }
+
   private fun prepareStorage() {
     runBlocking {
       storageClient.writeBlob(BLOB_KEY_1, "content1".toByteStringUtf8())

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -167,25 +167,24 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
   }
 
   @Test
-  fun `listBlobKeys returns both direct files and directory prefixes`(): Unit = runBlocking {
-    // Files directly at the prefix level
-    storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
-    storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
-    // Files inside subdirectories
-    storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
-    storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
-    storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
+  fun `listBlobKeys excludes direct files and only returns directory prefixes`(): Unit =
+    runBlocking {
+      // Files directly at the prefix level (should NOT be returned)
+      storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
+      storageClient.writeBlob("path/file2.txt", "data".toByteStringUtf8())
+      // Files inside subdirectories (should be grouped into directory prefixes)
+      storageClient.writeBlob("path/dir1/nested1.txt", "data".toByteStringUtf8())
+      storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
+      storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
 
-    val keys = storageClient.listBlobKeys("path/", "/").toList()
+      val keys = storageClient.listBlobKeys("path/", "/").toList()
 
-    // Should return direct files and directory prefixes, but NOT nested files
-    assertThat(keys).containsExactly(
-      "path/dir1/",
-      "path/dir2/",
-      "path/file1.txt",
-      "path/file2.txt",
-    )
-  }
+      // Should only return directory prefixes, not direct files or nested files
+      assertThat(keys).containsExactly(
+        "path/dir1/",
+        "path/dir2/",
+      )
+    }
 
   private fun prepareStorage() {
     runBlocking {

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractStorageClientTest.kt
@@ -133,37 +133,37 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
   }
 
   @Test
-  fun `listDelimitedBlobKeys returns unique prefixes for given delimiter`(): Unit = runBlocking {
+  fun `listBlobKeysAndPrefixes returns unique prefixes for given delimiter`(): Unit = runBlocking {
     storageClient.writeBlob("path/2026-03-13/done", "done".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-13/data1", "data".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-13/data2", "data".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-14/done", "done".toByteStringUtf8())
     storageClient.writeBlob("path/2026-03-15/done", "done".toByteStringUtf8())
 
-    val prefixes = storageClient.listDelimitedBlobKeys("path/").toList()
+    val prefixes = storageClient.listBlobKeysAndPrefixes("path/").toList()
 
     assertThat(prefixes).containsExactly("path/2026-03-13/", "path/2026-03-14/", "path/2026-03-15/")
   }
 
   @Test
-  fun `listDelimitedBlobKeys returns empty flow for non-existent prefix`(): Unit = runBlocking {
-    val prefixes = storageClient.listDelimitedBlobKeys("non-existent/").toList()
+  fun `listBlobKeysAndPrefixes returns empty flow for non-existent prefix`(): Unit = runBlocking {
+    val prefixes = storageClient.listBlobKeysAndPrefixes("non-existent/").toList()
     assertThat(prefixes).isEmpty()
   }
 
   @Test
-  fun `listDelimitedBlobKeys does not return nested prefixes`(): Unit = runBlocking {
+  fun `listBlobKeysAndPrefixes does not return nested prefixes`(): Unit = runBlocking {
     storageClient.writeBlob("a/b/c/file1", "data".toByteStringUtf8())
     storageClient.writeBlob("a/b/d/file2", "data".toByteStringUtf8())
 
-    val prefixes = storageClient.listDelimitedBlobKeys("a/").toList()
+    val prefixes = storageClient.listBlobKeysAndPrefixes("a/").toList()
 
     // Should only return the immediate child prefix, not nested ones
     assertThat(prefixes).containsExactly("a/b/")
   }
 
   @Test
-  fun `listDelimitedBlobKeys returns both direct files and directory prefixes`(): Unit =
+  fun `listBlobKeysAndPrefixes returns both direct files and directory prefixes`(): Unit =
     runBlocking {
       // Files directly at the prefix level
       storageClient.writeBlob("path/file1.txt", "data".toByteStringUtf8())
@@ -173,7 +173,7 @@ abstract class AbstractStorageClientTest<T : StorageClient> {
       storageClient.writeBlob("path/dir1/nested2.txt", "data".toByteStringUtf8())
       storageClient.writeBlob("path/dir2/nested3.txt", "data".toByteStringUtf8())
 
-      val keys = storageClient.listDelimitedBlobKeys("path/").toList()
+      val keys = storageClient.listBlobKeysAndPrefixes("path/").toList()
 
       // Should return direct files and directory prefixes, but NOT nested files
       assertThat(keys)

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -60,7 +60,7 @@ class InMemoryStorageClient : StorageClient {
   private inner class Blob(override val blobKey: String, private val content: ByteString) :
     StorageClient.Blob {
 
-    override val createTime: Instant? = Instant.now()
+    override val createTime: Instant = Instant.now()
 
     override val size: Long
       get() = content.size().toLong()

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -15,6 +15,7 @@
 package org.wfanet.measurement.storage.testing
 
 import com.google.protobuf.ByteString
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -58,6 +59,8 @@ class InMemoryStorageClient : StorageClient {
 
   private inner class Blob(override val blobKey: String, private val content: ByteString) :
     StorageClient.Blob {
+
+    override val createTime: Instant? = Instant.now()
 
     override val size: Long
       get() = content.size().toLong()

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -36,7 +36,9 @@ class InMemoryStorageClient : StorageClient {
   }
 
   override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
-    val blob = Blob(blobKey, content.flatten())
+    val now = Instant.now()
+    val existingCreateTime = storageMap[blobKey]?.createTime
+    val blob = Blob(blobKey, content.flatten(), existingCreateTime ?: now, now)
     storageMap[blobKey] = blob
     return blob
   }
@@ -57,10 +59,12 @@ class InMemoryStorageClient : StorageClient {
     }
   }
 
-  private inner class Blob(override val blobKey: String, private val content: ByteString) :
-    StorageClient.Blob {
-
-    override val createTime: Instant = Instant.now()
+  private inner class Blob(
+    override val blobKey: String,
+    private val content: ByteString,
+    override val createTime: Instant,
+    override val updateTime: Instant,
+  ) : StorageClient.Blob {
 
     override val size: Long
       get() = content.size().toLong()

--- a/src/main/proto/wfa/measurement/internal/testing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/testing/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "forwarded_storage_service_proto",
     srcs = ["forwarded_storage_service.proto"],
+    deps = ["@com_google_protobuf//:timestamp_proto"],
 )
 
 kt_jvm_grpc_proto_library(

--- a/src/main/proto/wfa/measurement/internal/testing/forwarded_storage_service.proto
+++ b/src/main/proto/wfa/measurement/internal/testing/forwarded_storage_service.proto
@@ -38,6 +38,7 @@ message BlobMetadata {
   int64 size = 1;
   string blob_key = 2;
   google.protobuf.Timestamp create_time = 3;
+  google.protobuf.Timestamp update_time = 4;
 }
 
 message WriteBlobRequest {

--- a/src/main/proto/wfa/measurement/internal/testing/forwarded_storage_service.proto
+++ b/src/main/proto/wfa/measurement/internal/testing/forwarded_storage_service.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package wfa.measurement.internal.testing;
 
+import "google/protobuf/timestamp.proto";
+
 option java_package = "org.wfanet.measurement.internal.testing";
 option java_multiple_files = true;
 
@@ -35,6 +37,7 @@ service ForwardedStorage {
 message BlobMetadata {
   int64 size = 1;
   string blob_key = 2;
+  google.protobuf.Timestamp create_time = 3;
 }
 
 message WriteBlobRequest {

--- a/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
@@ -312,6 +312,7 @@ class MesosRecordIoStorageClientTest {
   private class FakeBlob(private val chunks: List<ByteString>) : StorageClient.Blob {
     override val blobKey: String = "fake"
     override val size: Long = chunks.sumOf { it.size().toLong() }
+    override val createTime: java.time.Instant? = null
     override val storageClient: StorageClient
       get() = throw UnsupportedOperationException("n/a")
 

--- a/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
@@ -313,6 +313,7 @@ class MesosRecordIoStorageClientTest {
     override val blobKey: String = "fake"
     override val size: Long = chunks.sumOf { it.size().toLong() }
     override val createTime: java.time.Instant = java.time.Instant.now()
+    override val updateTime: java.time.Instant = createTime
     override val storageClient: StorageClient
       get() = throw UnsupportedOperationException("n/a")
 

--- a/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/MesosRecordIoStorageClientTest.kt
@@ -312,7 +312,7 @@ class MesosRecordIoStorageClientTest {
   private class FakeBlob(private val chunks: List<ByteString>) : StorageClient.Blob {
     override val blobKey: String = "fake"
     override val size: Long = chunks.sumOf { it.size().toLong() }
-    override val createTime: java.time.Instant? = null
+    override val createTime: java.time.Instant = java.time.Instant.now()
     override val storageClient: StorageClient
       get() = throw UnsupportedOperationException("n/a")
 

--- a/src/test/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageServiceTest.kt
@@ -38,6 +38,7 @@ import org.wfanet.measurement.storage.testing.AbstractStorageClientTest
 
 @RunWith(JUnit4::class)
 class FileSystemStorageServiceTest : AbstractStorageClientTest<ForwardedStorageClient>() {
+  override val supportsCreateTime: Boolean = false
   private val tempDirectory = TemporaryFolder()
   private val grpcTestServerRule = GrpcTestServerRule {
     addService(FileSystemStorageService(tempDirectory.root, Dispatchers.IO))

--- a/src/test/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/filesystem/FileSystemStorageServiceTest.kt
@@ -38,7 +38,6 @@ import org.wfanet.measurement.storage.testing.AbstractStorageClientTest
 
 @RunWith(JUnit4::class)
 class FileSystemStorageServiceTest : AbstractStorageClientTest<ForwardedStorageClient>() {
-  override val supportsCreateTime: Boolean = false
   private val tempDirectory = TemporaryFolder()
   private val grpcTestServerRule = GrpcTestServerRule {
     addService(FileSystemStorageService(tempDirectory.root, Dispatchers.IO))


### PR DESCRIPTION
  Adds Blob.createTime and Blob.updateTime properties to the StorageClient.Blob interface, along with listBlobsCreatedAfter(prefix, after),
  listBlobsUpdatedAfter(prefix, after), and listBlobKeysAndPrefixes(prefix) methods to StorageClient with default client-side filtering implementations.

  Concrete implementations updated:
  - GcsStorageClient: createTime from createTimeOffsetDateTime, updateTime from updateTimeOffsetDateTime.
  - S3StorageClient: Both use lastModified() since S3 does not have a separate creation time unless versioning is enabled.
  - FileSystemStorageClient: createTime from BasicFileAttributes.creationTime(), updateTime from File.lastModified().
  - InMemoryStorageClient: Tracks createTime in the stored object so it persists across overwrites; updateTime reflects the latest write.
  - ForwardedStorageClient/Service: create_time and update_time added to the BlobMetadata proto and wired through gRPC.
  - MesosRecordIoStorageClient and crypto wrappers (Aead, Kms, StreamingAead): Delegate both properties to the wrapped blob.


These additions support the data availability monitor's late-arriving files check, which compares file timestamps against the done blob to detect race conditions.

https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/3672