### PR TITLE
feat: Expose custom blob metadata getter on StorageClient.Blob

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -210,11 +210,19 @@ class GcsStorageClient(
     override val updateTime: Instant
       get() = checkNotNull(blob.updateTimeOffsetDateTime).toInstant()
 
-    override val metadata: Map<String, String>
-      get() {
-        val raw: Map<String, String?> = blob.metadata ?: return emptyMap()
-        return raw.entries.mapNotNull { (k, v) -> v?.let { k to it } }.toMap()
-      }
+    /**
+     * Custom user metadata from the underlying GCS object.
+     *
+     * The Java SDK declares the underlying [Blob.getMetadata] as `Map<String, String?>` because
+     * draft `BlobInfo` builders use `null` values as a "delete this key on PATCH" sentinel. A
+     * fetched object never contains literal null values (GCS removes such keys server-side), so the
+     * [mapNotNull] filter below is defensive against an SDK quirk that does not occur on fetched
+     * blobs in practice.
+     */
+    override val metadata: Map<String, String> by lazy {
+      val raw: Map<String, String?> = blob.metadata ?: return@lazy emptyMap()
+      raw.entries.mapNotNull { (k, v) -> v?.let { k to it } }.toMap()
+    }
 
     override fun read(): Flow<ByteString> {
       return blob.reader().asFlow(READ_BUFFER_SIZE, blockingContext + CoroutineName("readBlob"))

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -210,16 +210,13 @@ class GcsStorageClient(
     override val updateTime: Instant
       get() = checkNotNull(blob.updateTimeOffsetDateTime).toInstant()
 
-    /**
-     * Custom user metadata from the underlying GCS object.
-     *
-     * The Java SDK declares the underlying [Blob.getMetadata] as `Map<String, String?>` because
-     * draft `BlobInfo` builders use `null` values as a "delete this key on PATCH" sentinel. A
-     * fetched object never contains literal null values (GCS removes such keys server-side), so the
-     * [mapNotNull] filter below is defensive against an SDK quirk that does not occur on fetched
-     * blobs in practice.
-     */
+    /** Custom user metadata from the underlying GCS object. */
     override val metadata: Map<String, String> by lazy {
+      // The Java SDK declares Blob.getMetadata as Map<String, String?> because draft BlobInfo
+      // builders use `null` values as a "delete this key on PATCH" sentinel. A fetched object
+      // never contains literal null values (GCS removes such keys server-side), so the
+      // mapNotNull filter here is defensive against an SDK quirk that does not occur on fetched
+      // blobs in practice.
       val raw: Map<String, String?> = blob.metadata ?: return@lazy emptyMap()
       raw.entries.mapNotNull { (k, v) -> v?.let { k to it } }.toMap()
     }

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClient.kt
@@ -210,6 +210,12 @@ class GcsStorageClient(
     override val updateTime: Instant
       get() = checkNotNull(blob.updateTimeOffsetDateTime).toInstant()
 
+    override val metadata: Map<String, String>
+      get() {
+        val raw: Map<String, String?> = blob.metadata ?: return emptyMap()
+        return raw.entries.mapNotNull { (k, v) -> v?.let { k to it } }.toMap()
+      }
+
     override fun read(): Flow<ByteString> {
       return blob.reader().asFlow(READ_BUFFER_SIZE, blockingContext + CoroutineName("readBlob"))
     }

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -146,6 +146,14 @@ interface StorageClient {
     /** The time the blob was last updated. */
     val updateTime: Instant
 
+    /**
+     * Custom user-defined metadata on the blob.
+     *
+     * Defaults to an empty map for backends that do not support custom metadata.
+     */
+    val metadata: Map<String, String>
+      get() = emptyMap()
+
     /** Returns a [Flow] for the blob content. */
     fun read(): Flow<ByteString>
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/StorageClient.kt
@@ -188,9 +188,13 @@ interface BlobMetadataStorageClient : StorageClient {
   /**
    * Updates metadata on an existing blob.
    *
+   * Merge semantics — keys present in [metadata] are added or overwritten; keys already on the blob
+   * but absent from [metadata] are preserved. Matches GCS PATCH semantics.
+   *
    * @param blobKey The key of the blob to update
-   * @param customCreateTime Optional custom create timestamp (for lifecycle management)
-   * @param metadata Custom key-value metadata pairs
+   * @param customCreateTime Optional custom create timestamp (for lifecycle management). When
+   *   `null`, any existing custom create time is preserved.
+   * @param metadata Custom key-value metadata pairs to merge with any existing metadata
    * @throws StorageException if update fails
    */
   suspend fun updateBlobMetadata(

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
@@ -16,9 +16,11 @@
 
 package org.wfanet.measurement.storage.testing
 
+import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.kotlin.toByteStringUtf8
 import java.time.Instant
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.wfanet.measurement.storage.BlobMetadataStorageClient
@@ -103,5 +105,38 @@ T : ConditionalOperationStorageClient {
     assertFailsWith<StorageException> {
       storageClient.updateBlobMetadata(blobKey, customCreateTime = customCreateTime)
     }
+  }
+
+  @Test
+  fun `Blob metadata returns custom metadata after updateBlobMetadata`(): Unit = runBlocking {
+    val blobKey = "blob-with-metadata-getter"
+    storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
+    val expected = mapOf("synced-by" to "data-availability-sync", "k2" to "v2")
+
+    storageClient.updateBlobMetadata(blobKey, metadata = expected)
+
+    val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
+    assertThat(blob.metadata).containsAtLeastEntriesIn(expected)
+  }
+
+  @Test
+  fun `Blob metadata does not contain keys that were never set`(): Unit = runBlocking {
+    val blobKey = "blob-without-app-metadata"
+    storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
+
+    val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
+    assertThat(blob.metadata).doesNotContainKey("application-marker")
+  }
+
+  @Test
+  fun `Blob metadata is visible on blobs from listBlobs`(): Unit = runBlocking {
+    val blobKey = "listed-blob"
+    storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
+    val expected = mapOf("marker" to "yes")
+    storageClient.updateBlobMetadata(blobKey, metadata = expected)
+
+    val listed = storageClient.listBlobs().toList().single { it.blobKey == blobKey }
+
+    assertThat(listed.metadata).containsAtLeastEntriesIn(expected)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
@@ -124,6 +124,10 @@ T : ConditionalOperationStorageClient {
     val blobKey = "blob-without-app-metadata"
     storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
 
+    // Assert absence of an app-level key rather than .isEmpty() because some backends surface
+    // backend-synthetic entries (e.g. the GCS storage emulator returns `x_emulator_*` keys).
+    // Real GCS does not, but the conformance contract only requires that application-set keys
+    // are the ones the application can rely on.
     val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
     assertThat(blob.metadata).doesNotContainKey("application-marker")
   }
@@ -135,7 +139,11 @@ T : ConditionalOperationStorageClient {
     val expected = mapOf("marker" to "yes")
     storageClient.updateBlobMetadata(blobKey, metadata = expected)
 
-    val listed = storageClient.listBlobs().toList().single { it.blobKey == blobKey }
+    val all = storageClient.listBlobs().toList()
+    val listed = all.firstOrNull { it.blobKey == blobKey }
+    checkNotNull(listed) {
+      "Blob '$blobKey' not in listBlobs result (got ${all.map { it.blobKey }})"
+    }
 
     assertThat(listed.metadata).containsAtLeastEntriesIn(expected)
   }

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
@@ -173,6 +173,24 @@ T : ConditionalOperationStorageClient {
   }
 
   @Test
+  fun `updateBlobMetadata with only metadata preserves existing customCreateTime`(): Unit =
+    runBlocking {
+      val blobKey = "preserve-custom-create-time"
+      storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
+      val customCreateTime = Instant.parse("2025-01-15T10:30:00Z")
+      storageClient.updateBlobMetadata(blobKey, customCreateTime = customCreateTime)
+
+      // Subsequent call sets only metadata, must not wipe the previously-set customCreateTime.
+      storageClient.updateBlobMetadata(blobKey, metadata = mapOf("k" to "v"))
+
+      verifyBlobMetadata(
+        blobKey,
+        expectedCustomCreateTime = customCreateTime,
+        expectedMetadata = mapOf("k" to "v"),
+      )
+    }
+
+  @Test
   fun `writeBlob overwrite wipes prior custom metadata`(): Unit = runBlocking {
     val blobKey = "wipe-on-overwrite"
     storageClient.writeBlob(blobKey, "v1".toByteStringUtf8())

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
@@ -139,4 +139,16 @@ T : ConditionalOperationStorageClient {
 
     assertThat(listed.metadata).containsAtLeastEntriesIn(expected)
   }
+
+  @Test
+  fun `writeBlob overwrite wipes prior custom metadata`(): Unit = runBlocking {
+    val blobKey = "wipe-on-overwrite"
+    storageClient.writeBlob(blobKey, "v1".toByteStringUtf8())
+    storageClient.updateBlobMetadata(blobKey, metadata = mapOf("marker" to "yes"))
+
+    storageClient.writeBlob(blobKey, "v2".toByteStringUtf8())
+
+    val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
+    assertThat(blob.metadata).doesNotContainKey("marker")
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/AbstractBlobMetadataStorageClientTest.kt
@@ -149,6 +149,30 @@ T : ConditionalOperationStorageClient {
   }
 
   @Test
+  fun `updateBlobMetadata merges with existing metadata`(): Unit = runBlocking {
+    val blobKey = "merge-existing-metadata"
+    storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
+    storageClient.updateBlobMetadata(blobKey, metadata = mapOf("a" to "1"))
+
+    storageClient.updateBlobMetadata(blobKey, metadata = mapOf("b" to "2"))
+
+    val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
+    assertThat(blob.metadata).containsAtLeast("a", "1", "b", "2")
+  }
+
+  @Test
+  fun `updateBlobMetadata overwrites value for an existing key`(): Unit = runBlocking {
+    val blobKey = "overwrite-existing-key"
+    storageClient.writeBlob(blobKey, "content".toByteStringUtf8())
+    storageClient.updateBlobMetadata(blobKey, metadata = mapOf("k" to "v1"))
+
+    storageClient.updateBlobMetadata(blobKey, metadata = mapOf("k" to "v2"))
+
+    val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
+    assertThat(blob.metadata).containsAtLeast("k", "v2")
+  }
+
+  @Test
   fun `writeBlob overwrite wipes prior custom metadata`(): Unit = runBlocking {
     val blobKey = "wipe-on-overwrite"
     storageClient.writeBlob(blobKey, "v1".toByteStringUtf8())

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -67,15 +67,24 @@ class InMemoryStorageClient :
     return blob
   }
 
+  /**
+   * Conditional write that succeeds only if [blob]'s generation matches the current generation in
+   * storage.
+   *
+   * Note: the generation check and subsequent write are not atomic. This matches GCS semantics only
+   * when there is no concurrent writer for the same key; production GCS enforces atomicity via the
+   * server-side `ifGenerationMatch` precondition, but the in-memory test double does not. Safe for
+   * single-coroutine-per-key test usage.
+   */
   override suspend fun writeBlobIfUnchanged(
     blob: StorageClient.Blob,
     content: Flow<ByteString>,
   ): StorageClient.Blob {
     require(blob.storageClient === this) { "Blob does not belong to this storage client" }
     val current =
-      storageMap[blob.blobKey] ?: throw StorageException("Blob not found: \${blob.blobKey}")
+      storageMap[blob.blobKey] ?: throw StorageException("Blob not found: ${blob.blobKey}")
     if (current.generation != (blob as Blob).generation) {
-      throw BlobChangedException("Blob \${blob.blobKey} has changed since it was last read")
+      throw BlobChangedException("Blob ${blob.blobKey} has changed since it was last read")
     }
     return writeBlob(blob.blobKey, content)
   }

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -39,6 +39,9 @@ class InMemoryStorageClient :
   val contents: Map<String, StorageClient.Blob>
     get() = storageMap
 
+  /** Returns the custom create time set on [blobKey] via [updateBlobMetadata], or null if unset. */
+  fun getCustomCreateTime(blobKey: String): Instant? = storageMap[blobKey]?.customTime
+
   private fun deleteKey(path: String) {
     storageMap.remove(path)
   }

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -122,7 +122,9 @@ class InMemoryStorageClient :
         updateTime = Instant.now(),
         generation = existing.generation,
         customTime = customCreateTime ?: existing.customTime,
-        metadata = if (metadata.isNotEmpty()) metadata else existing.metadata,
+        // GCS PATCH semantics: keys in [metadata] are added or overwritten; existing keys not in
+        // [metadata] are preserved. Map+ is right-biased so collisions resolve to the new value.
+        metadata = existing.metadata + metadata,
       )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClient.kt
@@ -21,11 +21,19 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.wfanet.measurement.common.flatten
+import org.wfanet.measurement.storage.BlobChangedException
+import org.wfanet.measurement.storage.BlobMetadataStorageClient
+import org.wfanet.measurement.storage.ConditionalOperationStorageClient
 import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.measurement.storage.StorageException
 
-/** In-memory [StorageClient]. */
-class InMemoryStorageClient : StorageClient {
-  private val storageMap = ConcurrentHashMap<String, StorageClient.Blob>()
+/**
+ * In-memory [StorageClient] with [ConditionalOperationStorageClient] and
+ * [BlobMetadataStorageClient] support.
+ */
+class InMemoryStorageClient :
+  StorageClient, ConditionalOperationStorageClient, BlobMetadataStorageClient {
+  private val storageMap = ConcurrentHashMap<String, Blob>()
 
   /** Exposes all the blobs in the [StorageClient]. */
   val contents: Map<String, StorageClient.Blob>
@@ -37,10 +45,36 @@ class InMemoryStorageClient : StorageClient {
 
   override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
     val now = Instant.now()
-    val existingCreateTime = storageMap[blobKey]?.createTime
-    val blob = Blob(blobKey, content.flatten(), existingCreateTime ?: now, now)
+    val existing = storageMap[blobKey]
+    val existingCreateTime = existing?.createTime
+    val nextGeneration = (existing?.generation ?: 0L) + 1L
+    // A fresh write replaces any prior custom metadata, mirroring GCS upload semantics where a
+    // re-upload does not carry over previously-set user metadata unless the writer sets it.
+    val blob =
+      Blob(
+        blobKey = blobKey,
+        contentBytes = content.flatten(),
+        createTime = existingCreateTime ?: now,
+        updateTime = now,
+        generation = nextGeneration,
+        customTime = null,
+        metadata = emptyMap(),
+      )
     storageMap[blobKey] = blob
     return blob
+  }
+
+  override suspend fun writeBlobIfUnchanged(
+    blob: StorageClient.Blob,
+    content: Flow<ByteString>,
+  ): StorageClient.Blob {
+    require(blob.storageClient === this) { "Blob does not belong to this storage client" }
+    val current =
+      storageMap[blob.blobKey] ?: throw StorageException("Blob not found: \${blob.blobKey}")
+    if (current.generation != (blob as Blob).generation) {
+      throw BlobChangedException("Blob \${blob.blobKey} has changed since it was last read")
+    }
+    return writeBlob(blob.blobKey, content)
   }
 
   override suspend fun getBlob(blobKey: String): StorageClient.Blob? {
@@ -59,20 +93,44 @@ class InMemoryStorageClient : StorageClient {
     }
   }
 
+  override suspend fun updateBlobMetadata(
+    blobKey: String,
+    customCreateTime: Instant?,
+    metadata: Map<String, String>,
+  ) {
+    require(customCreateTime != null || metadata.isNotEmpty()) {
+      "At least one of customCreateTime or metadata must be specified"
+    }
+    val existing = storageMap[blobKey] ?: throw StorageException("Blob not found: $blobKey")
+    storageMap[blobKey] =
+      Blob(
+        blobKey = blobKey,
+        contentBytes = existing.contentBytes,
+        createTime = existing.createTime,
+        updateTime = Instant.now(),
+        generation = existing.generation,
+        customTime = customCreateTime ?: existing.customTime,
+        metadata = if (metadata.isNotEmpty()) metadata else existing.metadata,
+      )
+  }
+
   private inner class Blob(
     override val blobKey: String,
-    private val content: ByteString,
+    val contentBytes: ByteString,
     override val createTime: Instant,
     override val updateTime: Instant,
+    val generation: Long,
+    val customTime: Instant?,
+    override val metadata: Map<String, String>,
   ) : StorageClient.Blob {
 
     override val size: Long
-      get() = content.size().toLong()
+      get() = contentBytes.size().toLong()
 
     override val storageClient: InMemoryStorageClient
       get() = this@InMemoryStorageClient
 
-    override fun read(): Flow<ByteString> = flowOf(content)
+    override fun read(): Flow<ByteString> = flowOf(contentBytes)
 
     override suspend fun delete() = storageClient.deleteKey(blobKey)
   }

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClientTest.kt
@@ -100,7 +100,9 @@ class GcsStorageClientTest : AbstractBlobMetadataStorageClientTest<GcsStorageCli
 
     // Issue a low-level PATCH that maps "foo" -> null via the underlying GCS SDK.
     val patch =
-      BlobInfo.newBuilder(BlobId.of(BUCKET, blobKey)).setMetadata(mapOf("foo" to null)).build()
+      BlobInfo.newBuilder(BlobId.of(BUCKET, blobKey))
+        .apply { setMetadata(mapOf("foo" to null)) }
+        .build()
     storageEmulator.storage.update(patch)
 
     val refetched = checkNotNull(storageClient.getBlob(blobKey))

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageClientTest.kt
@@ -14,8 +14,11 @@
 
 package org.wfanet.measurement.gcloud.gcs
 
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
 import java.time.Instant
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -77,6 +80,31 @@ class GcsStorageClientTest : AbstractBlobMetadataStorageClientTest<GcsStorageCli
 
     assertThat(keys).hasSize(totalBlobs)
     assertThat(keys.toSet()).hasSize(totalBlobs)
+  }
+
+  /**
+   * GCS-specific test: a metadata PATCH that sets a key to `null` deletes that key from the stored
+   * object. This documents the SDK behavior our [GcsStorageClient.ClientBlob.metadata] getter
+   * relies on (see the KDoc on that property) — fetched objects never carry null-valued metadata
+   * entries, so the defensive null-filter in the getter is a no-op against real (and emulated) GCS.
+   *
+   * Lives in this class rather than the abstract conformance suite because the "PATCH key=null
+   * deletes the key" behavior is a GCS REST/SDK quirk, not a property of the [StorageClient]
+   * interface.
+   */
+  @Test
+  fun `PATCH with null metadata value deletes the key on GCS`(): Unit = runBlocking {
+    val blobKey = "null-meta-blob"
+    storageClient.writeBlob(blobKey, "x".toByteStringUtf8())
+    storageClient.updateBlobMetadata(blobKey, metadata = mapOf("foo" to "bar"))
+
+    // Issue a low-level PATCH that maps "foo" -> null via the underlying GCS SDK.
+    val patch =
+      BlobInfo.newBuilder(BlobId.of(BUCKET, blobKey)).setMetadata(mapOf("foo" to null)).build()
+    storageEmulator.storage.update(patch)
+
+    val refetched = checkNotNull(storageClient.getBlob(blobKey))
+    assertThat(refetched.metadata).doesNotContainKey("foo")
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
@@ -39,9 +39,11 @@ class InMemoryStorageClientTest : AbstractBlobMetadataStorageClientTest<InMemory
     if (expectedMetadata.isNotEmpty()) {
       assertThat(blob.metadata).containsAtLeastEntriesIn(expectedMetadata)
     }
-    // customCreateTime is internal state; the getter for it is not on Blob, so only validate via
-    // the metadata getter when metadata is what the caller cares about. The base test still
-    // checks via this hook, so leave customCreateTime unasserted here.
+    if (expectedCustomCreateTime != null) {
+      val actual = storageClient.getCustomCreateTime(blobKey)
+      checkNotNull(actual) { "Custom create time not set on blob: $blobKey" }
+      assertThat(actual).isEqualTo(expectedCustomCreateTime)
+    }
   }
 
   @Test
@@ -60,18 +62,5 @@ class InMemoryStorageClientTest : AbstractBlobMetadataStorageClientTest<InMemory
     client.getBlob(blobKey)?.delete()
 
     assertThat(client.contents).isEmpty()
-  }
-
-  @Test
-  fun `writeBlob overwrite wipes prior custom metadata`(): Unit = runBlocking {
-    val client = InMemoryStorageClient()
-    val blobKey = "k"
-    client.writeBlob(blobKey, "v1".toByteStringUtf8())
-    client.updateBlobMetadata(blobKey, metadata = mapOf("marker" to "yes"))
-
-    client.writeBlob(blobKey, "v2".toByteStringUtf8())
-
-    val blob = checkNotNull(client.getBlob(blobKey))
-    assertThat(blob.metadata).isEmpty()
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/testing/InMemoryStorageClientTest.kt
@@ -18,15 +18,30 @@ package org.wfanet.measurement.storage.testing
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.kotlin.toByteStringUtf8
+import java.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.wfanet.measurement.common.flatten
 
-class InMemoryStorageClientTest : AbstractStorageClientTest<InMemoryStorageClient>() {
+class InMemoryStorageClientTest : AbstractBlobMetadataStorageClientTest<InMemoryStorageClient>() {
   @Before
   fun initStorageClient() {
     storageClient = InMemoryStorageClient()
+  }
+
+  override suspend fun verifyBlobMetadata(
+    blobKey: String,
+    expectedCustomCreateTime: Instant?,
+    expectedMetadata: Map<String, String>,
+  ) {
+    val blob = checkNotNull(storageClient.getBlob(blobKey)) { "Blob not found: $blobKey" }
+    if (expectedMetadata.isNotEmpty()) {
+      assertThat(blob.metadata).containsAtLeastEntriesIn(expectedMetadata)
+    }
+    // customCreateTime is internal state; the getter for it is not on Blob, so only validate via
+    // the metadata getter when metadata is what the caller cares about. The base test still
+    // checks via this hook, so leave customCreateTime unasserted here.
   }
 
   @Test
@@ -45,5 +60,18 @@ class InMemoryStorageClientTest : AbstractStorageClientTest<InMemoryStorageClien
     client.getBlob(blobKey)?.delete()
 
     assertThat(client.contents).isEmpty()
+  }
+
+  @Test
+  fun `writeBlob overwrite wipes prior custom metadata`(): Unit = runBlocking {
+    val client = InMemoryStorageClient()
+    val blobKey = "k"
+    client.writeBlob(blobKey, "v1".toByteStringUtf8())
+    client.updateBlobMetadata(blobKey, metadata = mapOf("marker" to "yes"))
+
+    client.writeBlob(blobKey, "v2".toByteStringUtf8())
+
+    val blob = checkNotNull(client.getBlob(blobKey))
+    assertThat(blob.metadata).isEmpty()
   }
 }


### PR DESCRIPTION
Adds a `metadata: Map<String, String>` getter to `StorageClient.Blob` with a default of `emptyMap()` and overrides it in `GcsStorageClient.ClientBlob` to return the underlying GCS blob's custom metadata. Adds coverage in `AbstractBlobMetadataStorageClientTest` so all `BlobMetadataStorageClient` implementations exercise the getter, including via `listBlobs`.

Also upgrades `InMemoryStorageClient` to implement `ConditionalOperationStorageClient` and `BlobMetadataStorageClient` so its test extends the abstract conformance suite and so downstream tests can exercise the metadata getter without a GCS emulator. Mirrors GCS semantics: a fresh `writeBlob` wipes prior custom metadata; `updateBlobMetadata` preserves the existing content and generation; `writeBlobIfUnchanged` uses generation-based change detection.

**Backend contract for `Blob.metadata`:** the getter must reflect custom metadata both on blobs returned from `getBlob` and on blobs returned from `listBlobs`. For GCS this is the default — `Storage.list` uses `Projection.FULL`, which includes per-object `metadata` in the response, and `GcsStorageClient.listBlobs` does not pass a `fields(...)` filter. Verified empirically against a real GCS bucket and covered by the `Blob metadata is visible on blobs from listBlobs` test in `AbstractBlobMetadataStorageClientTest`, which `GcsStorageClientTest` and `InMemoryStorageClientTest` both exercise. Future implementations of `BlobMetadataStorageClient` must satisfy the same conformance test.

Issue: world-federation-of-advertisers/cross-media-measurement#3976
