### PR TITLE
feat: add ParquetStorageClient.writeBlob overload that embeds footer key-value metadata

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
@@ -246,10 +246,9 @@ class ParquetStorageClient(
 
   /**
    * Encodes [content] (a flow of serialized [ParquetRow]) into a parquet file at [blobKey],
-   * optionally embedding [keyValueMetadata] into the file's footer key-value metadata (empty by
-   * default). The schema is derived from the first row; see the class KDoc for the first-row
-   * constraint. An empty flow writes a valid, zero-row parquet file, which still carries
-   * [keyValueMetadata].
+   * embedding [keyValueMetadata] into the file's footer key-value metadata. The schema is derived
+   * from the first row; see the class KDoc for the first-row constraint. An empty flow writes a
+   * valid, zero-row parquet file, which still carries [keyValueMetadata].
    *
    * The written entries are the inverse of [ParquetBlob.readKeyValueMetadata], which reads them
    * back. When PME is configured in `ENCRYPTED_FOOTER` mode the footer (and therefore this
@@ -260,7 +259,7 @@ class ParquetStorageClient(
   suspend fun writeBlob(
     blobKey: String,
     content: Flow<ByteString>,
-    keyValueMetadata: Map<String, String> = emptyMap(),
+    keyValueMetadata: Map<String, String>,
   ): StorageClient.Blob {
     val path = resolvePath(blobKey)
     withContext(parquetContext) {

--- a/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
@@ -240,19 +240,16 @@ class ParquetStorageClient(
 
   // === StorageClient ===
 
-  /**
-   * Encodes [content] (a flow of serialized [ParquetRow]) into a parquet file at [blobKey]. The
-   * schema is derived from the first row; see the class KDoc for the first-row constraint. An empty
-   * flow writes a valid, zero-row parquet file.
-   */
+  /** Delegates to [writeBlob] with no footer key-value metadata. */
   override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob =
     writeBlob(blobKey, content, emptyMap())
 
   /**
    * Encodes [content] (a flow of serialized [ParquetRow]) into a parquet file at [blobKey],
-   * embedding [keyValueMetadata] into the file's footer key-value metadata. The schema is derived
-   * from the first row; see the class KDoc for the first-row constraint. An empty flow still writes
-   * a valid, zero-row parquet file, and it too carries [keyValueMetadata].
+   * optionally embedding [keyValueMetadata] into the file's footer key-value metadata (empty by
+   * default). The schema is derived from the first row; see the class KDoc for the first-row
+   * constraint. An empty flow writes a valid, zero-row parquet file, which still carries
+   * [keyValueMetadata].
    *
    * The written entries are the inverse of [ParquetBlob.readKeyValueMetadata], which reads them
    * back. When PME is configured in `ENCRYPTED_FOOTER` mode the footer (and therefore this
@@ -263,7 +260,7 @@ class ParquetStorageClient(
   suspend fun writeBlob(
     blobKey: String,
     content: Flow<ByteString>,
-    keyValueMetadata: Map<String, String>,
+    keyValueMetadata: Map<String, String> = emptyMap(),
   ): StorageClient.Blob {
     val path = resolvePath(blobKey)
     withContext(parquetContext) {

--- a/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
@@ -116,7 +116,9 @@ data class ParquetEncryptionConfig(
  * in the flow is one serialized [ParquetRow]. This makes the [StorageClient] contract parquet-aware
  * on both ends — `writeBlob` encodes rows into a parquet file, `read` decodes them back — but note
  * it is NOT the opaque byte pass-through that the other [StorageClient] implementations provide;
- * the unit of content here is a row, not a file.
+ * the unit of content here is a row, not a file. The [writeBlob] overload taking `keyValueMetadata`
+ * additionally embeds footer key-value metadata that [ParquetBlob.readKeyValueMetadata] reads back
+ * (see that overload for the PME footer caveat).
  *
  * ## Type mapping
  *
@@ -243,7 +245,26 @@ class ParquetStorageClient(
    * schema is derived from the first row; see the class KDoc for the first-row constraint. An empty
    * flow writes a valid, zero-row parquet file.
    */
-  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob =
+    writeBlob(blobKey, content, emptyMap())
+
+  /**
+   * Encodes [content] (a flow of serialized [ParquetRow]) into a parquet file at [blobKey],
+   * embedding [keyValueMetadata] into the file's footer key-value metadata. The schema is derived
+   * from the first row; see the class KDoc for the first-row constraint. An empty flow still writes
+   * a valid, zero-row parquet file, and it too carries [keyValueMetadata].
+   *
+   * The written entries are the inverse of [ParquetBlob.readKeyValueMetadata], which reads them
+   * back. When PME is configured in `ENCRYPTED_FOOTER` mode the footer (and therefore this
+   * metadata) is encrypted on disk and [ParquetBlob.readKeyValueMetadata] cannot read it; write
+   * with `PLAINTEXT_FOOTER` (`parquet.encryption.plaintext.footer = true`) if the metadata must
+   * stay readable without the footer key.
+   */
+  suspend fun writeBlob(
+    blobKey: String,
+    content: Flow<ByteString>,
+    keyValueMetadata: Map<String, String>,
+  ): StorageClient.Blob {
     val path = resolvePath(blobKey)
     withContext(parquetContext) {
       val outputFile: OutputFile = HadoopOutputFile.fromPath(path, conf)
@@ -258,7 +279,7 @@ class ParquetStorageClient(
             schema = deriveSchema(row)
             expectedKinds = row.columnsMap.mapValues { it.value.kindCase }
             factory = SimpleGroupFactory(schema)
-            writer = newWriter(outputFile, schema!!)
+            writer = newWriter(outputFile, schema!!, keyValueMetadata)
             logger.fine { "Writing '$blobKey' with ${schema!!.fields.size} columns" }
           }
           validateRow(row, expectedKinds!!)
@@ -268,7 +289,7 @@ class ParquetStorageClient(
           // Parquet rejects an empty (zero-column) schema, so empty input
           // writes a single placeholder column with zero rows; reads then
           // yield no rows.
-          writer = newWriter(outputFile, EMPTY_SCHEMA)
+          writer = newWriter(outputFile, EMPTY_SCHEMA, keyValueMetadata)
         }
       } catch (t: Throwable) {
         // Release the open writer without masking the original failure, then
@@ -587,15 +608,21 @@ class ParquetStorageClient(
 
   // === Write: schema derivation + Group construction ===
 
-  private fun newWriter(outputFile: OutputFile, schema: MessageType): ParquetWriter<Group> =
+  private fun newWriter(
+    outputFile: OutputFile,
+    schema: MessageType,
+    keyValueMetadata: Map<String, String>,
+  ): ParquetWriter<Group> =
     // ExampleParquetWriter installs a GroupWriteSupport bound to this schema.
     // When a PME crypto factory is configured on `conf`, the writer encrypts
-    // automatically; otherwise it writes plaintext.
+    // automatically; otherwise it writes plaintext. `withExtraMetaData` writes
+    // the entries into the footer key-value metadata (an empty map adds none).
     ExampleParquetWriter.builder(outputFile)
       .withConf(conf)
       .withType(schema)
       .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
       .withCompressionCodec(compressionCodec)
+      .withExtraMetaData(keyValueMetadata)
       .build()
 
   /**

--- a/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
@@ -170,6 +170,30 @@ class ParquetStorageClientTest {
   }
 
   @Test
+  fun `writeBlob embeds keyValueMetadata into the footer`(): Unit = runBlocking {
+    val client = newClient()
+
+    client.writeBlob(
+      "meta.parquet",
+      flowOf(encRow()),
+      mapOf("edpa.kek_uri" to "fake-kms://kek", "shard" to "3"),
+    )
+
+    assertThat(client.getBlob("meta.parquet")!!.readKeyValueMetadata())
+      .containsAtLeast("edpa.kek_uri", "fake-kms://kek", "shard", "3")
+  }
+
+  @Test
+  fun `writeBlob embeds keyValueMetadata on an empty zero-row blob`(): Unit = runBlocking {
+    val client = newClient()
+
+    client.writeBlob("empty-meta.parquet", emptyFlow(), mapOf("foo" to "bar"))
+
+    assertThat(client.getBlob("empty-meta.parquet")!!.readKeyValueMetadata())
+      .containsAtLeast("foo", "bar")
+  }
+
+  @Test
   fun `getBlob returns null for missing key`(): Unit = runBlocking {
     assertThat(newClient().getBlob("nothing-here.parquet")).isNull()
   }

--- a/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
@@ -718,6 +718,30 @@ class ParquetStorageClientTest {
   }
 
   @Test
+  fun `writeBlob keyValueMetadata round-trips through a plaintext-footer encrypted blob`(): Unit =
+    runBlocking {
+      val kekUri = "fake-kms://uniform-kek"
+      // PLAINTEXT_FOOTER keeps the footer (and its key-value metadata) readable
+      // without keys, so the writeBlob(keyValueMetadata) overload composes with
+      // encryption: an encrypting client embeds the metadata and a fresh
+      // plaintext client reads the exact entries back with no crypto config.
+      val conf =
+        Configuration().apply {
+          set("parquet.encryption.uniform.key", kekUri)
+          setBoolean("parquet.encryption.plaintext.footer", true)
+        }
+      newEncryptingClient(conf, fakeKms(kekUri))
+        .writeBlob(
+          "enc-meta.parquet",
+          flowOf(encRow()),
+          mapOf("edpa.kek_uri" to "fake-kms://kek", "shard" to "3"),
+        )
+
+      assertThat(newClient().getBlob("enc-meta.parquet")!!.readKeyValueMetadata())
+        .containsAtLeast("edpa.kek_uri", "fake-kms://kek", "shard", "3")
+    }
+
+  @Test
   fun `keyMapping resolves a short master-key name to a Tink URI`(): Unit = runBlocking {
     val kekUri = "fake-kms://uniform-kek"
     // The file references the short name "uniform-key" (parquet's column.keys


### PR DESCRIPTION
## Summary

  `ParquetStorageClient` could already **read** footer key-value metadata via
  `ParquetBlob.readKeyValueMetadata()`, but had no way to **write** it. This adds the
  missing write counterpart: a `writeBlob` overload that accepts a
  `Map<String, String>` and embeds those entries into the parquet file's footer
  key-value metadata.

  ## Changes
  
  - New overload
    `suspend fun writeBlob(blobKey, content, keyValueMetadata: Map<String, String>)`
    that embeds the entries into the footer via parquet-mr's
    `ParquetWriter.Builder.withExtraMetaData` (available since parquet 1.12.0; the
    repo pins 1.14.3).
  - The existing `override writeBlob(blobKey, content)` now delegates to the new
    overload with `emptyMap()` — **no behavior change** for current callers.
  - The private `newWriter(...)` gained a `keyValueMetadata` parameter, threaded
    through **both** writer call sites (the main first-row-derived-schema path and
    the zero-row `EMPTY_SCHEMA` fallback), so empty-flow writes carry metadata too.
  - KDoc updated on the class and the new overload, including the PME
    `ENCRYPTED_FOOTER` caveat (see below).

  ## Notes / caveats
  
  - The footer is written on close, so metadata must be supplied at file creation —
    there is no in-place footer mutation.
  - Written entries are the inverse of `readKeyValueMetadata()`. When PME is
    configured in `ENCRYPTED_FOOTER` mode, the footer (and thus this metadata) is
    encrypted on disk and cannot be read back without the footer key; use
    `PLAINTEXT_FOOTER` (`parquet.encryption.plaintext.footer = true`) if the
    metadata must stay readable without the footer key.
  - No BUILD change required — `parquet_hadoop` is already a dependency.

  ## Testing
  
  Two new round-trip tests in `ParquetStorageClientTest.kt` (non-empty blob and
  empty/zero-row blob):

  //src/test/kotlin/org/wfanet/measurement/storage:ParquetStorageClientTest

Issue: world-federation-of-advertisers/cross-media-measurement#3948