### PR TITLE
feat(storage): expose ParquetBlob.readSchema()

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
@@ -225,6 +225,15 @@ class ParquetStorageClient(
      * Throws [IllegalStateException] if the file is a PME `ENCRYPTED_FOOTER` blob (not supported).
      */
     suspend fun readKeyValueMetadata(): Map<String, String>
+
+    /**
+     * The file's parquet schema as a map of column name to the [ParquetValue.KindCase] that
+     * [readRows] yields for that column (same parquet-type -> kind mapping documented on
+     * [readRows]). Reads only the schema, not row values; returns an empty map for a zero-row file.
+     * Lets a caller validate up front that a config's referenced columns exist with the expected
+     * types, instead of discovering a missing/renamed column silently at row time.
+     */
+    suspend fun readSchema(): Map<String, ParquetValue.KindCase>
   }
 
   // === StorageClient ===
@@ -373,6 +382,15 @@ class ParquetStorageClient(
     override suspend fun readKeyValueMetadata(): Map<String, String> =
       withContext(parquetContext) { readFooterKeyValueMetadata(path) }
 
+    override suspend fun readSchema(): Map<String, ParquetValue.KindCase> =
+      withContext(parquetContext) {
+        val inputFile: InputFile = HadoopInputFile.fromPath(path, conf)
+        GroupParquetReaderBuilder(inputFile).withConf(conf).build().use { reader ->
+          val first = reader.read() ?: return@use emptyMap<String, ParquetValue.KindCase>()
+          first.type.fields.associate { field -> field.name to kindOf(field) }
+        }
+      }
+
     override suspend fun delete() {
       withContext(parquetContext) { fileSystem.delete(path, /* recursive= */ false) }
     }
@@ -498,6 +516,53 @@ class ParquetStorageClient(
           ByteString.copyFrom(g.getBinary(name, 0).toByteBuffer())
         }
       PrimitiveTypeName.INT96 -> { g -> ByteString.copyFrom(g.getInt96(name, 0).bytes) }
+    }
+  }
+
+  /**
+   * The [ParquetValue.KindCase] that [ParquetBlob.readRows] produces for [field], per the mapping
+   * documented on [ParquetBlob.readRows]. Mirrors the primitive/logical-type dispatch in
+   * [buildPrimitiveExtractor] (schema-only; no [Group] needed), so [ParquetBlob.readSchema]
+   * declares exactly the kinds a row read would yield.
+   */
+  private fun kindOf(field: Type): ParquetValue.KindCase {
+    check(field.isPrimitive) {
+      "Nested message field '${field.name}' is not supported by ParquetStorageClient"
+    }
+    val prim = field.asPrimitiveType()
+    val annotation = prim.logicalTypeAnnotation
+    return when (prim.primitiveTypeName) {
+      PrimitiveTypeName.INT32 ->
+        when {
+          annotation is LogicalTypeAnnotation.DateLogicalTypeAnnotation ->
+            ParquetValue.KindCase.DATE_VALUE
+          annotation is LogicalTypeAnnotation.IntLogicalTypeAnnotation && !annotation.isSigned ->
+            ParquetValue.KindCase.UINT32_VALUE
+          else -> ParquetValue.KindCase.INT32_VALUE
+        }
+      PrimitiveTypeName.INT64 ->
+        when {
+          annotation is LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ->
+            ParquetValue.KindCase.TIMESTAMP_VALUE
+          annotation is LogicalTypeAnnotation.IntLogicalTypeAnnotation && !annotation.isSigned ->
+            ParquetValue.KindCase.UINT64_VALUE
+          else -> ParquetValue.KindCase.INT64_VALUE
+        }
+      PrimitiveTypeName.FLOAT -> ParquetValue.KindCase.FLOAT_VALUE
+      PrimitiveTypeName.DOUBLE -> ParquetValue.KindCase.DOUBLE_VALUE
+      PrimitiveTypeName.BOOLEAN -> ParquetValue.KindCase.BOOL_VALUE
+      PrimitiveTypeName.BINARY ->
+        if (
+          annotation is LogicalTypeAnnotation.StringLogicalTypeAnnotation ||
+            annotation is LogicalTypeAnnotation.EnumLogicalTypeAnnotation ||
+            annotation is LogicalTypeAnnotation.JsonLogicalTypeAnnotation
+        ) {
+          ParquetValue.KindCase.STRING_VALUE
+        } else {
+          ParquetValue.KindCase.BYTES_VALUE
+        }
+      PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY -> ParquetValue.KindCase.BYTES_VALUE
+      PrimitiveTypeName.INT96 -> ParquetValue.KindCase.BYTES_VALUE
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
@@ -44,6 +44,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.parquet.example.data.Group
 import org.apache.parquet.example.data.simple.SimpleGroupFactory
 import org.apache.parquet.format.Util
+import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileWriter
 import org.apache.parquet.hadoop.ParquetReader
 import org.apache.parquet.hadoop.ParquetWriter
@@ -231,9 +232,11 @@ class ParquetStorageClient(
     /**
      * The file's parquet schema as a map of column name to the [ParquetValue.KindCase] that
      * [readRows] yields for that column (same parquet-type -> kind mapping documented on
-     * [readRows]). Reads only the schema, not row values; returns an empty map for a zero-row file.
-     * Lets a caller validate up front that a config's referenced columns exist with the expected
-     * types, instead of discovering a missing/renamed column silently at row time.
+     * [readRows]). Read directly from the footer's schema — no row values are decoded — so it
+     * reflects the declared schema even for a zero-row file (every valid parquet file stores its
+     * schema in the footer regardless of row count). Lets a caller validate up front that a
+     * config's referenced columns exist with the expected types, instead of discovering a
+     * missing/renamed column silently at row time.
      */
     suspend fun readSchema(): Map<String, ParquetValue.KindCase>
   }
@@ -400,13 +403,7 @@ class ParquetStorageClient(
       withContext(parquetContext) { readFooterKeyValueMetadata(path) }
 
     override suspend fun readSchema(): Map<String, ParquetValue.KindCase> =
-      withContext(parquetContext) {
-        val inputFile: InputFile = HadoopInputFile.fromPath(path, conf)
-        GroupParquetReaderBuilder(inputFile).withConf(conf).build().use { reader ->
-          val first = reader.read() ?: return@use emptyMap<String, ParquetValue.KindCase>()
-          first.type.fields.associate { field -> field.name to kindOf(field) }
-        }
-      }
+      withContext(parquetContext) { readFooterSchema(path) }
 
     override suspend fun delete() {
       withContext(parquetContext) { fileSystem.delete(path, /* recursive= */ false) }
@@ -741,8 +738,8 @@ class ParquetStorageClient(
   // === Direct thrift footer parse (bypasses ParquetFileReader) ===
 
   /**
-   * Reads the parquet file's footer key-value metadata directly from the thrift `FileMetaData`
-   * struct, bypassing parquet-mr's high-level `ParquetFileReader`.
+   * Reads the parquet file's footer `FileMetaData` thrift struct directly (schema + key-value
+   * metadata), bypassing parquet-mr's high-level `ParquetFileReader` and skipping the row groups.
    *
    * Why bypass: under PME `PLAINTEXT_FOOTER` mode the footer body (schema, key-value metadata) IS
    * plaintext on disk, but per-column metadata is still encrypted with the footer key.
@@ -751,20 +748,21 @@ class ParquetStorageClient(
    *
    * Solution: read the raw FileMetaData thrift struct via `Util.readFileMetaData(in, skipRowGroups
    * = true)`. Skipping row groups means the encrypted per-column-metadata blobs are never touched;
-   * only file-level fields, including the always-plaintext `key_value_metadata`, are returned.
+   * only file-level fields, including the always-plaintext `schema` and `key_value_metadata`, are
+   * returned.
    *
    * Parquet footer trailer layout (last 8 bytes): `[int32 footer length LE][4-byte magic]`. Magic
    * is `"PAR1"` for plaintext-footer files (including PME `PLAINTEXT_FOOTER`). `"PARE"` indicates
    * PME `ENCRYPTED_FOOTER`, which we explicitly REJECT: that mode stores a `FileCryptoMetaData`
    * thrift followed by the encrypted `FileMetaData`, so the parse would hit ciphertext.
    */
-  private fun readFooterKeyValueMetadata(path: Path): Map<String, String> {
+  private fun readFooterFileMetaData(path: Path): org.apache.parquet.format.FileMetaData {
     val inputFile = HadoopInputFile.fromPath(path, conf)
     val fileLen = inputFile.length
     require(fileLen >= MIN_PARQUET_FILE_SIZE) {
       "File too small to be parquet: $path (size=$fileLen)"
     }
-    inputFile.newStream().use { stream ->
+    return inputFile.newStream().use { stream ->
       // Read the 8-byte trailer: [footer length: int32 LE][magic: 4 bytes].
       val tail = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
       stream.seek(fileLen - 8)
@@ -777,8 +775,8 @@ class ParquetStorageClient(
         throw IllegalStateException(
           "Parquet file '$path' uses PME ENCRYPTED_FOOTER mode, which is not supported by " +
             "ParquetStorageClient. Re-write the file with PLAINTEXT_FOOTER mode " +
-            "(FileEncryptionProperties.Builder.withPlaintextFooter()) so the footer key-value " +
-            "metadata can be read without the footer key."
+            "(FileEncryptionProperties.Builder.withPlaintextFooter()) so the footer schema and " +
+            "key-value metadata can be read without the footer key."
         )
       }
       require(magic == PARQUET_MAGIC_PLAINTEXT) { "Not a parquet file: $path (bad magic '$magic')" }
@@ -791,10 +789,28 @@ class ParquetStorageClient(
       stream.readFully(footerBuf)
       footerBuf.flip()
       val footerBytes = ByteArray(footerLen).also { footerBuf.get(it) }
-      val md = Util.readFileMetaData(ByteArrayInputStream(footerBytes), /* skipRowGroups= */ true)
-      val kv = md.key_value_metadata ?: return emptyMap()
-      return kv.associate { it.key to (it.value ?: "") }
+      Util.readFileMetaData(ByteArrayInputStream(footerBytes), /* skipRowGroups= */ true)
     }
+  }
+
+  /**
+   * The footer's key-value metadata (the inverse of [writeBlob]'s `keyValueMetadata`). Empty when
+   * the file carries none.
+   */
+  private fun readFooterKeyValueMetadata(path: Path): Map<String, String> {
+    val kv = readFooterFileMetaData(path).key_value_metadata ?: return emptyMap()
+    return kv.associate { it.key to (it.value ?: "") }
+  }
+
+  /**
+   * The footer's declared schema as a column-name -> [ParquetValue.KindCase] map (via [kindOf], the
+   * same mapping [readRows] uses). Available for a zero-row file, since the schema is stored in the
+   * footer independent of row count.
+   */
+  private fun readFooterSchema(path: Path): Map<String, ParquetValue.KindCase> {
+    val md = readFooterFileMetaData(path)
+    val schema = ParquetMetadataConverter().fromParquetMetadata(md).fileMetaData.schema
+    return schema.fields.associate { it.name to kindOf(it) }
   }
 
   private companion object {

--- a/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/ParquetStorageClient.kt
@@ -116,7 +116,9 @@ data class ParquetEncryptionConfig(
  * in the flow is one serialized [ParquetRow]. This makes the [StorageClient] contract parquet-aware
  * on both ends — `writeBlob` encodes rows into a parquet file, `read` decodes them back — but note
  * it is NOT the opaque byte pass-through that the other [StorageClient] implementations provide;
- * the unit of content here is a row, not a file.
+ * the unit of content here is a row, not a file. The [writeBlob] overload taking `keyValueMetadata`
+ * additionally embeds footer key-value metadata that [ParquetBlob.readKeyValueMetadata] reads back
+ * (see that overload for the PME footer caveat).
  *
  * ## Type mapping
  *
@@ -238,12 +240,27 @@ class ParquetStorageClient(
 
   // === StorageClient ===
 
+  /** Delegates to [writeBlob] with no footer key-value metadata. */
+  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob =
+    writeBlob(blobKey, content, emptyMap())
+
   /**
-   * Encodes [content] (a flow of serialized [ParquetRow]) into a parquet file at [blobKey]. The
-   * schema is derived from the first row; see the class KDoc for the first-row constraint. An empty
-   * flow writes a valid, zero-row parquet file.
+   * Encodes [content] (a flow of serialized [ParquetRow]) into a parquet file at [blobKey],
+   * embedding [keyValueMetadata] into the file's footer key-value metadata. The schema is derived
+   * from the first row; see the class KDoc for the first-row constraint. An empty flow writes a
+   * valid, zero-row parquet file, which still carries [keyValueMetadata].
+   *
+   * The written entries are the inverse of [ParquetBlob.readKeyValueMetadata], which reads them
+   * back. When PME is configured in `ENCRYPTED_FOOTER` mode the footer (and therefore this
+   * metadata) is encrypted on disk and [ParquetBlob.readKeyValueMetadata] cannot read it; write
+   * with `PLAINTEXT_FOOTER` (`parquet.encryption.plaintext.footer = true`) if the metadata must
+   * stay readable without the footer key.
    */
-  override suspend fun writeBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+  suspend fun writeBlob(
+    blobKey: String,
+    content: Flow<ByteString>,
+    keyValueMetadata: Map<String, String>,
+  ): StorageClient.Blob {
     val path = resolvePath(blobKey)
     withContext(parquetContext) {
       val outputFile: OutputFile = HadoopOutputFile.fromPath(path, conf)
@@ -258,7 +275,7 @@ class ParquetStorageClient(
             schema = deriveSchema(row)
             expectedKinds = row.columnsMap.mapValues { it.value.kindCase }
             factory = SimpleGroupFactory(schema)
-            writer = newWriter(outputFile, schema!!)
+            writer = newWriter(outputFile, schema!!, keyValueMetadata)
             logger.fine { "Writing '$blobKey' with ${schema!!.fields.size} columns" }
           }
           validateRow(row, expectedKinds!!)
@@ -268,7 +285,7 @@ class ParquetStorageClient(
           // Parquet rejects an empty (zero-column) schema, so empty input
           // writes a single placeholder column with zero rows; reads then
           // yield no rows.
-          writer = newWriter(outputFile, EMPTY_SCHEMA)
+          writer = newWriter(outputFile, EMPTY_SCHEMA, keyValueMetadata)
         }
       } catch (t: Throwable) {
         // Release the open writer without masking the original failure, then
@@ -587,15 +604,21 @@ class ParquetStorageClient(
 
   // === Write: schema derivation + Group construction ===
 
-  private fun newWriter(outputFile: OutputFile, schema: MessageType): ParquetWriter<Group> =
+  private fun newWriter(
+    outputFile: OutputFile,
+    schema: MessageType,
+    keyValueMetadata: Map<String, String>,
+  ): ParquetWriter<Group> =
     // ExampleParquetWriter installs a GroupWriteSupport bound to this schema.
     // When a PME crypto factory is configured on `conf`, the writer encrypts
-    // automatically; otherwise it writes plaintext.
+    // automatically; otherwise it writes plaintext. `withExtraMetaData` writes
+    // the entries into the footer key-value metadata (an empty map adds none).
     ExampleParquetWriter.builder(outputFile)
       .withConf(conf)
       .withType(schema)
       .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
       .withCompressionCodec(compressionCodec)
+      .withExtraMetaData(keyValueMetadata)
       .build()
 
   /**

--- a/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
@@ -139,6 +139,30 @@ class ParquetStorageClientTest {
     }
 
   @Test
+  fun `readSchema returns column name to value kind`(): Unit = runBlocking {
+    val key = plaintextSample("data.parquet")
+
+    val schema = newClient().getBlob(key)!!.readSchema()
+
+    assertThat(schema)
+      .containsExactly(
+        "id",
+        ParquetValue.KindCase.INT64_VALUE,
+        "name",
+        ParquetValue.KindCase.STRING_VALUE,
+        "data",
+        ParquetValue.KindCase.BYTES_VALUE,
+      )
+  }
+
+  @Test
+  fun `readSchema returns empty for a zero-row file`(): Unit = runBlocking {
+    val key = writeParquetBlob("empty.parquet", SAMPLE_SCHEMA, emptyList(), null, emptyMap(), null)
+
+    assertThat(newClient().getBlob(key)!!.readSchema()).isEmpty()
+  }
+
+  @Test
   fun `readKeyValueMetadata returns plaintext footer entries`(): Unit = runBlocking {
     val key = plaintextSample("data.parquet", metadata = mapOf("foo" to "bar"))
 

--- a/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
@@ -156,10 +156,18 @@ class ParquetStorageClientTest {
   }
 
   @Test
-  fun `readSchema returns empty for a zero-row file`(): Unit = runBlocking {
+  fun `readSchema returns declared schema for a zero-row file`(): Unit = runBlocking {
     val key = writeParquetBlob("empty.parquet", SAMPLE_SCHEMA, emptyList(), null, emptyMap(), null)
 
-    assertThat(newClient().getBlob(key)!!.readSchema()).isEmpty()
+    assertThat(newClient().getBlob(key)!!.readSchema())
+      .containsExactly(
+        "id",
+        ParquetValue.KindCase.INT64_VALUE,
+        "name",
+        ParquetValue.KindCase.STRING_VALUE,
+        "data",
+        ParquetValue.KindCase.BYTES_VALUE,
+      )
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/ParquetStorageClientTest.kt
@@ -170,6 +170,30 @@ class ParquetStorageClientTest {
   }
 
   @Test
+  fun `writeBlob embeds keyValueMetadata into the footer`(): Unit = runBlocking {
+    val client = newClient()
+
+    client.writeBlob(
+      "meta.parquet",
+      flowOf(encRow()),
+      mapOf("edpa.kek_uri" to "fake-kms://kek", "shard" to "3"),
+    )
+
+    assertThat(client.getBlob("meta.parquet")!!.readKeyValueMetadata())
+      .containsAtLeast("edpa.kek_uri", "fake-kms://kek", "shard", "3")
+  }
+
+  @Test
+  fun `writeBlob embeds keyValueMetadata on an empty zero-row blob`(): Unit = runBlocking {
+    val client = newClient()
+
+    client.writeBlob("empty-meta.parquet", emptyFlow(), mapOf("foo" to "bar"))
+
+    assertThat(client.getBlob("empty-meta.parquet")!!.readKeyValueMetadata())
+      .containsAtLeast("foo", "bar")
+  }
+
+  @Test
   fun `getBlob returns null for missing key`(): Unit = runBlocking {
     assertThat(newClient().getBlob("nothing-here.parquet")).isNull()
   }
@@ -692,6 +716,30 @@ class ParquetStorageClientTest {
     // Plaintext footer stays readable without keys.
     assertThat(newClient().getBlob("enc.parquet")!!.readKeyValueMetadata()).isNotNull()
   }
+
+  @Test
+  fun `writeBlob keyValueMetadata round-trips through a plaintext-footer encrypted blob`(): Unit =
+    runBlocking {
+      val kekUri = "fake-kms://uniform-kek"
+      // PLAINTEXT_FOOTER keeps the footer (and its key-value metadata) readable
+      // without keys, so the writeBlob(keyValueMetadata) overload composes with
+      // encryption: an encrypting client embeds the metadata and a fresh
+      // plaintext client reads the exact entries back with no crypto config.
+      val conf =
+        Configuration().apply {
+          set("parquet.encryption.uniform.key", kekUri)
+          setBoolean("parquet.encryption.plaintext.footer", true)
+        }
+      newEncryptingClient(conf, fakeKms(kekUri))
+        .writeBlob(
+          "enc-meta.parquet",
+          flowOf(encRow()),
+          mapOf("edpa.kek_uri" to "fake-kms://kek", "shard" to "3"),
+        )
+
+      assertThat(newClient().getBlob("enc-meta.parquet")!!.readKeyValueMetadata())
+        .containsAtLeast("edpa.kek_uri", "fake-kms://kek", "shard", "3")
+    }
 
   @Test
   fun `keyMapping resolves a short master-key name to a Tink URI`(): Unit = runBlocking {


### PR DESCRIPTION
## Summary

Adds `ParquetBlob.readSchema(): Map<String, ParquetValue.KindCase>` — the file's column name → the `ParquetValue` kind that `readRows()` yields for it (same parquet-type → kind mapping already documented on `readRows`), reading only the schema (empty map for a zero-row file).

## Motivation

Downstream consumers map config fields to Parquet **column names** but only ever see per-row value maps, so a config that references a non-existent/renamed column is indistinguishable from a null cell and fails silently (the field is left unset). Exposing the schema lets a caller validate up front that every referenced column exists with the expected type and fail loud, instead of discovering drift at row time.

## Changes

- `ParquetBlob.readSchema()` on the interface + `ParquetBlobImpl`.
- Private `kindOf(Type)` mirroring `buildPrimitiveExtractor`'s primitive/logical-type dispatch, so the declared kinds match what a row read would produce.
- Tests: column-name→kind mapping; empty (zero-row) file returns empty.
