### PR TITLE
feat: resilient GCS retry/timeout defaults for transient reads

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
@@ -8,7 +8,9 @@ kt_jvm_library(
     name = "gcs",
     srcs = glob(["*.kt"]),
     deps = [
+        "//imports/java/com/google/api/gax",
         "//imports/java/com/google/cloud/storage",
+        "//imports/java/io/opentelemetry/api",
         "//imports/java/picocli",
         "//imports/kotlin/kotlinx/coroutines:core",
         "//src/main/kotlin/org/wfanet/measurement/common",

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsFromFlags.kt
@@ -19,18 +19,25 @@ import com.google.cloud.storage.StorageOptions
 import org.wfanet.measurement.common.Instrumentation
 import picocli.CommandLine
 
-/** Client access provider for Google Cloud Storage (GCS) via command-line flags. */
-class GcsFromFlags(private val flags: Flags) {
+/**
+ * Client access provider for Google Cloud Storage (GCS) via command-line flags.
+ *
+ * @param flags command-line flags
+ * @param retryConfig resilient retry/timeout configuration applied to the GCS client; defaults to
+ *   [GcsStorageRetryConfig.DEFAULT]
+ */
+class GcsFromFlags(
+  private val flags: Flags,
+  private val retryConfig: GcsStorageRetryConfig = GcsStorageRetryConfig.DEFAULT,
+) {
 
   private val storageOptions: StorageOptions by lazy {
-    val builder =
-      if (flags.useGrpc) {
-        StorageOptions.grpc().setEnableGrpcClientMetrics(true)
-      } else {
-        StorageOptions.newBuilder()
-      }
-
-    builder.setOpenTelemetry(Instrumentation.openTelemetry).setProjectId(flags.projectName).build()
+    buildGcsStorageOptions(
+      projectId = flags.projectName,
+      useGrpc = flags.useGrpc,
+      openTelemetry = Instrumentation.openTelemetry,
+      retryConfig = retryConfig,
+    )
   }
 
   val storage: Storage

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsFromFlags.kt
@@ -32,11 +32,10 @@ class GcsFromFlags(
 ) {
 
   private val storageOptions: StorageOptions by lazy {
-    buildGcsStorageOptions(
+    retryConfig.buildStorageOptions(
       projectId = flags.projectName,
       useGrpc = flags.useGrpc,
       openTelemetry = Instrumentation.openTelemetry,
-      retryConfig = retryConfig,
     )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
@@ -39,13 +39,22 @@ import java.time.Duration
  *   ([com.google.cloud.storage.ApiaryUnbufferedReadableByteChannel], which tracks `position` and
  *   re-opens with `withNewBeginOffset`).
  *
- * ## What bounds a stalled read on the HTTP/Apiary transport
- * The knob that aborts a stalled socket read is the transport read timeout
- * ([HttpTransportOptions.Builder.setReadTimeout] -> `HttpRequest.setReadTimeout` ->
- * `HttpURLConnection` `SO_TIMEOUT`), applied via [StorageOptions.Builder.setTransportOptions]. This
- * is distinct from [RetrySettings] RPC timeouts (`initialRpcTimeout`/`maxRpcTimeout`), which are
- * not enforced on the blocking Apiary HTTP read. [RetrySettings] here governs the retry budget
- * (`totalTimeout`, `maxAttempts`) and the jittered exponential backoff between attempts.
+ * ## What bounds an attempt (HTTP vs gRPC)
+ * The two transports bound a single attempt differently:
+ * * On the HTTP/Apiary transport, [readTimeout] is the transport socket read timeout
+ *   ([HttpTransportOptions.Builder.setReadTimeout] -> `HttpRequest.setReadTimeout` ->
+ *   `HttpURLConnection` `SO_TIMEOUT`), applied via [StorageOptions.Builder.setTransportOptions]. It
+ *   is an idle-gap bound: it aborts a read that stalls with no bytes for that long. The
+ *   [RetrySettings] RPC timeouts are inert here (they are not enforced on the blocking Apiary
+ *   read).
+ * * On the gRPC transport, there is no socket read timeout; the per-attempt bound is the
+ *   [RetrySettings] RPC timeout ([rpcTimeout]), which is a whole-attempt wall-clock deadline (not
+ *   an idle gap). The gRPC read channel also resumes at the current offset across attempts
+ *   ([com.google.cloud.storage.GapicUnbufferedReadableByteChannel] re-opens with `read_offset`), so
+ *   a large read completes in chunks within [totalTimeout].
+ *
+ * In both cases [RetrySettings] governs the retry budget (`totalTimeout`, `maxAttempts`) and the
+ * jittered exponential backoff between attempts.
  *
  * ## Scope
  * These [RetrySettings] and transport timeouts apply to ALL Storage operations (reads, writes, and
@@ -57,9 +66,12 @@ import java.time.Duration
  * The defaults are deliberately generous so that legitimate slow reads are not broken, while still
  * bounding each attempt so a stalled socket is aborted promptly and several bounded attempts fit in
  * the budget:
- * * [readTimeout] = 30s: a healthy Cloud Storage stream delivers data continuously, so 30s of
- *   silence indicates a real stall.
+ * * [readTimeout] = 30s (HTTP idle-read bound): a healthy Cloud Storage stream delivers data
+ *   continuously, so 30s of silence indicates a real stall.
  * * [connectTimeout] = 15s.
+ * * [rpcTimeout] = 60s (gRPC per-attempt whole-attempt deadline): the gax/storage `readObject`
+ *   default; generous enough for a chunk of a large read, which resumes at offset on the next
+ *   attempt.
  * * [totalTimeout] = 180s: room for several bounded attempts (each resuming at the current offset).
  * * [maxAttempts] = 6 with exponential backoff ([initialRetryDelay] 1s, [maxRetryDelay] 32s,
  *   [retryDelayMultiplier] 2.0). gax applies jitter to this backoff by default.
@@ -72,10 +84,17 @@ data class GcsStorageRetryConfig(
    */
   val connectTimeout: Duration = Duration.ofSeconds(15),
   /**
-   * Per-attempt socket read timeout. Maps to [HttpTransportOptions.Builder.setReadTimeout]; this is
-   * the knob that aborts a stalled socket read on the HTTP/Apiary transport.
+   * HTTP/Apiary per-attempt socket read timeout (an idle-gap bound). Maps to
+   * [HttpTransportOptions.Builder.setReadTimeout]; this is the knob that aborts a stalled socket
+   * read on the HTTP transport. Inert on the gRPC transport (see [rpcTimeout]).
    */
   val readTimeout: Duration = Duration.ofSeconds(30),
+  /**
+   * gRPC per-attempt RPC timeout (a whole-attempt wall-clock deadline, not an idle gap). Maps to
+   * [RetrySettings.Builder.setInitialRpcTimeout]/[RetrySettings.Builder.setMaxRpcTimeout]. Defaults
+   * to 60s, the gax/storage `readObject` default. Inert on the HTTP transport (see [readTimeout]).
+   */
+  val rpcTimeout: Duration = Duration.ofSeconds(60),
   /** Total retry budget across all attempts. Maps to [RetrySettings.Builder.setTotalTimeout]. */
   val totalTimeout: Duration = Duration.ofSeconds(180),
   /** Maximum number of attempts. Maps to [RetrySettings.Builder.setMaxAttempts]. */
@@ -94,6 +113,9 @@ data class GcsStorageRetryConfig(
     require(!readTimeout.isNegative && !readTimeout.isZero) {
       "readTimeout must be positive, got $readTimeout"
     }
+    require(!rpcTimeout.isNegative && !rpcTimeout.isZero) {
+      "rpcTimeout must be positive, got $rpcTimeout"
+    }
     require(!initialRetryDelay.isNegative && !initialRetryDelay.isZero) {
       "initialRetryDelay must be positive, got $initialRetryDelay"
     }
@@ -106,7 +128,11 @@ data class GcsStorageRetryConfig(
     }
     require(totalTimeout >= connectTimeout.plus(readTimeout)) {
       "totalTimeout ($totalTimeout) must be >= connectTimeout + readTimeout " +
-        "(${connectTimeout.plus(readTimeout)}) so at least one full attempt fits in the budget"
+        "(${connectTimeout.plus(readTimeout)}) so at least one full HTTP attempt fits in the budget"
+    }
+    require(totalTimeout >= rpcTimeout) {
+      "totalTimeout ($totalTimeout) must be >= rpcTimeout ($rpcTimeout) so at least one full gRPC " +
+        "attempt fits in the budget"
     }
   }
 
@@ -118,11 +144,11 @@ data class GcsStorageRetryConfig(
       .setMaxRetryDelayDuration(maxRetryDelay)
       .setMaxAttempts(maxAttempts)
       .setTotalTimeoutDuration(totalTimeout)
-      // The Apiary HTTP read is bounded by the socket read timeout, not the RPC timeout; keep the
-      // RPC timeout aligned with the read timeout so the gRPC transport (if used) bounds each
-      // attempt consistently.
-      .setInitialRpcTimeoutDuration(readTimeout)
-      .setMaxRpcTimeoutDuration(readTimeout)
+      // readTimeout is the HTTP socket idle-read bound (applied via HttpTransportOptions); the RPC
+      // timeout is the gRPC per-attempt whole-attempt deadline, so it maps to rpcTimeout, not
+      // readTimeout. The RPC timeout is inert on the HTTP/Apiary transport.
+      .setInitialRpcTimeoutDuration(rpcTimeout)
+      .setMaxRpcTimeoutDuration(rpcTimeout)
       .setRpcTimeoutMultiplier(1.0)
       .build()
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
@@ -1,0 +1,166 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.gcloud.gcs
+
+import com.google.api.gax.retrying.RetrySettings
+import com.google.cloud.http.HttpTransportOptions
+import com.google.cloud.storage.StorageOptions
+import io.opentelemetry.api.OpenTelemetry
+import java.time.Duration
+
+/**
+ * Resilience configuration applied to every [StorageOptions] built by [buildGcsStorageOptions].
+ *
+ * ## Why this exists
+ * The `google-cloud-storage` library defaults leave a Cloud Storage read vulnerable to transient
+ * connection glitches (observed in production as `Broken pipe` and `Remote host terminated the
+ * handshake` thrown from `BaseStorageReadChannel.read`):
+ * * The default retry budget is `totalTimeout = 50s` / `maxAttempts = 6`
+ *   (`com.google.cloud.ServiceOptions.getDefaultRetrySettingsBuilder`).
+ * * The default HTTP transport
+ *   ([com.google.cloud.storage.HttpStorageOptions.HttpStorageDefaults.getDefaultTransportOptions])
+ *   sets no explicit socket read timeout, so each socket read falls back to the google-http-client
+ *   `HttpRequest` default. That default bounds the idle gap between successive reads, not the total
+ *   download time, so a slow-but-progressing read can consume the entire 50s retry budget before a
+ *   second attempt can start. The read then fails after a single attempt even though the library's
+ *   read channel would otherwise resume mid-stream at the current offset via a `Range` request
+ *   ([com.google.cloud.storage.ApiaryUnbufferedReadableByteChannel], which tracks `position` and
+ *   re-opens with `withNewBeginOffset`).
+ *
+ * ## What bounds a stalled read on the HTTP/Apiary transport
+ * The knob that aborts a stalled socket read is the transport read timeout
+ * ([HttpTransportOptions.Builder.setReadTimeout] -> `HttpRequest.setReadTimeout` ->
+ * `HttpURLConnection` `SO_TIMEOUT`), applied via [StorageOptions.Builder.setTransportOptions]. This
+ * is distinct from [RetrySettings] RPC timeouts (`initialRpcTimeout`/`maxRpcTimeout`), which are
+ * not enforced on the blocking Apiary HTTP read. [RetrySettings] here governs the retry budget
+ * (`totalTimeout`, `maxAttempts`) and the jittered exponential backoff between attempts.
+ *
+ * ## Defaults
+ * The defaults are deliberately generous so that legitimate slow reads are not broken, while still
+ * bounding each attempt so a stalled socket is aborted promptly and several bounded attempts fit in
+ * the budget:
+ * * [readTimeout] = 30s: a healthy Cloud Storage stream delivers data continuously, so 30s of
+ *   silence indicates a real stall.
+ * * [connectTimeout] = 15s.
+ * * [totalTimeout] = 180s: room for several bounded attempts (each resuming at the current offset).
+ * * [maxAttempts] = 6 with exponential backoff ([initialRetryDelay] 1s, [maxRetryDelay] 32s,
+ *   [retryDelayMultiplier] 2.0). gax applies jitter to this backoff by default.
+ *
+ * All values are overridable so a caller (e.g. the Results-Fulfiller) can tune tighter later.
+ */
+data class GcsStorageRetryConfig(
+  /**
+   * Timeout to establish a connection. Maps to [HttpTransportOptions.Builder.setConnectTimeout].
+   */
+  val connectTimeout: Duration = Duration.ofSeconds(15),
+  /**
+   * Per-attempt socket read timeout. Maps to [HttpTransportOptions.Builder.setReadTimeout]; this is
+   * the knob that aborts a stalled socket read on the HTTP/Apiary transport.
+   */
+  val readTimeout: Duration = Duration.ofSeconds(30),
+  /** Total retry budget across all attempts. Maps to [RetrySettings.Builder.setTotalTimeout]. */
+  val totalTimeout: Duration = Duration.ofSeconds(180),
+  /** Maximum number of attempts. Maps to [RetrySettings.Builder.setMaxAttempts]. */
+  val maxAttempts: Int = 6,
+  /** Delay before the first retry. Maps to [RetrySettings.Builder.setInitialRetryDelay]. */
+  val initialRetryDelay: Duration = Duration.ofSeconds(1),
+  /** Maximum backoff delay between retries. Maps to [RetrySettings.Builder.setMaxRetryDelay]. */
+  val maxRetryDelay: Duration = Duration.ofSeconds(32),
+  /** Backoff multiplier. Maps to [RetrySettings.Builder.setRetryDelayMultiplier]. */
+  val retryDelayMultiplier: Double = 2.0,
+) {
+  init {
+    require(!connectTimeout.isNegative && !connectTimeout.isZero) {
+      "connectTimeout must be positive, got $connectTimeout"
+    }
+    require(!readTimeout.isNegative && !readTimeout.isZero) {
+      "readTimeout must be positive, got $readTimeout"
+    }
+    require(!initialRetryDelay.isNegative && !initialRetryDelay.isZero) {
+      "initialRetryDelay must be positive, got $initialRetryDelay"
+    }
+    require(maxRetryDelay >= initialRetryDelay) {
+      "maxRetryDelay ($maxRetryDelay) must be >= initialRetryDelay ($initialRetryDelay)"
+    }
+    require(maxAttempts >= 1) { "maxAttempts must be at least 1, got $maxAttempts" }
+    require(retryDelayMultiplier >= 1.0) {
+      "retryDelayMultiplier must be >= 1.0, got $retryDelayMultiplier"
+    }
+    require(totalTimeout >= readTimeout) {
+      "totalTimeout ($totalTimeout) must be >= readTimeout ($readTimeout) so at least one attempt " +
+        "fits in the budget"
+    }
+  }
+
+  /** [RetrySettings] derived from this config. */
+  fun toRetrySettings(): RetrySettings =
+    RetrySettings.newBuilder()
+      .setInitialRetryDelayDuration(initialRetryDelay)
+      .setRetryDelayMultiplier(retryDelayMultiplier)
+      .setMaxRetryDelayDuration(maxRetryDelay)
+      .setMaxAttempts(maxAttempts)
+      .setTotalTimeoutDuration(totalTimeout)
+      // The Apiary HTTP read is bounded by the socket read timeout, not the RPC timeout; keep the
+      // RPC timeout aligned with the read timeout so the gRPC transport (if used) bounds each
+      // attempt consistently.
+      .setInitialRpcTimeoutDuration(readTimeout)
+      .setMaxRpcTimeoutDuration(readTimeout)
+      .setRpcTimeoutMultiplier(1.0)
+      .build()
+
+  /** [HttpTransportOptions] derived from this config (HTTP/Apiary transport only). */
+  fun toHttpTransportOptions(): HttpTransportOptions =
+    HttpTransportOptions.newBuilder()
+      .setConnectTimeout(connectTimeout.toMillis().toInt())
+      .setReadTimeout(readTimeout.toMillis().toInt())
+      .build()
+
+  companion object {
+    /** The resilient default configuration used for all callers unless overridden. */
+    val DEFAULT = GcsStorageRetryConfig()
+  }
+}
+
+/**
+ * Builds [StorageOptions] for Google Cloud Storage with resilient retry/timeout settings applied by
+ * default (see [GcsStorageRetryConfig]).
+ *
+ * @param projectId GCS project id, or `null` to let the library resolve it from the environment.
+ * @param useGrpc whether to use the gRPC transport instead of HTTP. The HTTP transport read/connect
+ *   timeouts only apply to the HTTP transport; on gRPC the per-attempt bound is the RPC timeout.
+ * @param openTelemetry [OpenTelemetry] instance for client metrics/traces, or `null`.
+ * @param retryConfig resilience configuration; defaults to [GcsStorageRetryConfig.DEFAULT].
+ */
+fun buildGcsStorageOptions(
+  projectId: String? = null,
+  useGrpc: Boolean = false,
+  openTelemetry: OpenTelemetry? = null,
+  retryConfig: GcsStorageRetryConfig = GcsStorageRetryConfig.DEFAULT,
+): StorageOptions {
+  val builder: StorageOptions.Builder =
+    if (useGrpc) {
+      StorageOptions.grpc().setEnableGrpcClientMetrics(true)
+    } else {
+      StorageOptions.http().setTransportOptions(retryConfig.toHttpTransportOptions())
+    }
+  builder.setRetrySettings(retryConfig.toRetrySettings())
+  if (projectId != null) {
+    builder.setProjectId(projectId)
+  }
+  if (openTelemetry != null) {
+    builder.setOpenTelemetry(openTelemetry)
+  }
+  return builder.build()
+}

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
@@ -21,62 +21,9 @@ import io.opentelemetry.api.OpenTelemetry
 import java.time.Duration
 
 /**
- * Resilience configuration applied to every [StorageOptions] built by [buildGcsStorageOptions].
- *
- * ## Why this exists
- * The `google-cloud-storage` library defaults leave a Cloud Storage read vulnerable to transient
- * connection glitches (observed in production as `Broken pipe` and `Remote host terminated the
- * handshake` thrown from `BaseStorageReadChannel.read`):
- * * The default retry budget is `totalTimeout = 50s` / `maxAttempts = 6`
- *   (`com.google.cloud.ServiceOptions.getDefaultRetrySettingsBuilder`).
- * * The default HTTP transport
- *   ([com.google.cloud.storage.HttpStorageOptions.HttpStorageDefaults.getDefaultTransportOptions])
- *   sets no explicit socket read timeout, so each socket read falls back to the google-http-client
- *   `HttpRequest` default. That default bounds the idle gap between successive reads, not the total
- *   download time, so a slow-but-progressing read can consume the entire 50s retry budget before a
- *   second attempt can start. The read then fails after a single attempt even though the library's
- *   read channel would otherwise resume mid-stream at the current offset via a `Range` request
- *   ([com.google.cloud.storage.ApiaryUnbufferedReadableByteChannel], which tracks `position` and
- *   re-opens with `withNewBeginOffset`).
- *
- * ## What bounds an attempt (HTTP vs gRPC)
- * The two transports bound a single attempt differently:
- * * On the HTTP/Apiary transport, [readTimeout] is the transport socket read timeout
- *   ([HttpTransportOptions.Builder.setReadTimeout] -> `HttpRequest.setReadTimeout` ->
- *   `HttpURLConnection` `SO_TIMEOUT`), applied via [StorageOptions.Builder.setTransportOptions]. It
- *   is an idle-gap bound: it aborts a read that stalls with no bytes for that long. The
- *   [RetrySettings] RPC timeouts are inert here (they are not enforced on the blocking Apiary
- *   read).
- * * On the gRPC transport, there is no socket read timeout; the per-attempt bound is the
- *   [RetrySettings] RPC timeout ([rpcTimeout]), which is a whole-attempt wall-clock deadline (not
- *   an idle gap). The gRPC read channel also resumes at the current offset across attempts
- *   ([com.google.cloud.storage.GapicUnbufferedReadableByteChannel] re-opens with `read_offset`), so
- *   a large read completes in chunks within [totalTimeout].
- *
- * In both cases [RetrySettings] governs the retry budget (`totalTimeout`, `maxAttempts`) and the
- * jittered exponential backoff between attempts.
- *
- * ## Scope
- * These [RetrySettings] and transport timeouts apply to ALL Storage operations (reads, writes, and
- * metadata); the mid-stream resume-at-offset described above is the read-specific part, and the
- * library's default retry strategy only retries idempotent writes, so widening the retry budget
- * introduces no new double-write risk.
- *
- * ## Defaults
- * The defaults are deliberately generous so that legitimate slow reads are not broken, while still
- * bounding each attempt so a stalled socket is aborted promptly and several bounded attempts fit in
- * the budget:
- * * [readTimeout] = 30s (HTTP idle-read bound): a healthy Cloud Storage stream delivers data
- *   continuously, so 30s of silence indicates a real stall.
- * * [connectTimeout] = 15s.
- * * [rpcTimeout] = 60s (gRPC per-attempt whole-attempt deadline): the gax/storage `readObject`
- *   default; generous enough for a chunk of a large read, which resumes at offset on the next
- *   attempt.
- * * [totalTimeout] = 180s: room for several bounded attempts (each resuming at the current offset).
- * * [maxAttempts] = 6 with exponential backoff ([initialRetryDelay] 1s, [maxRetryDelay] 32s,
- *   [retryDelayMultiplier] 2.0). gax applies jitter to this backoff by default.
- *
- * All values are overridable so a caller (e.g. the Results-Fulfiller) can tune tighter later.
+ * Resilience configuration -- retry budget and per-attempt timeouts -- applied to every
+ * [StorageOptions] built by [buildStorageOptions]. Defaults are generous so legitimate slow reads
+ * are not broken, and are overridable.
  */
 data class GcsStorageRetryConfig(
   /**
@@ -84,15 +31,14 @@ data class GcsStorageRetryConfig(
    */
   val connectTimeout: Duration = Duration.ofSeconds(15),
   /**
-   * HTTP/Apiary per-attempt socket read timeout (an idle-gap bound). Maps to
-   * [HttpTransportOptions.Builder.setReadTimeout]; this is the knob that aborts a stalled socket
-   * read on the HTTP transport. Inert on the gRPC transport (see [rpcTimeout]).
+   * HTTP socket idle-read bound (max time with no bytes); inert on the gRPC transport. Maps to
+   * [HttpTransportOptions.Builder.setReadTimeout].
    */
   val readTimeout: Duration = Duration.ofSeconds(30),
   /**
-   * gRPC per-attempt RPC timeout (a whole-attempt wall-clock deadline, not an idle gap). Maps to
-   * [RetrySettings.Builder.setInitialRpcTimeout]/[RetrySettings.Builder.setMaxRpcTimeout]. Defaults
-   * to 60s, the gax/storage `readObject` default. Inert on the HTTP transport (see [readTimeout]).
+   * gRPC per-attempt (whole-attempt) deadline; inert on the HTTP transport. Defaults to the
+   * gax/storage `readObject` default of 60s. Maps to [RetrySettings.Builder.setInitialRpcTimeout] /
+   * [RetrySettings.Builder.setMaxRpcTimeout].
    */
   val rpcTimeout: Duration = Duration.ofSeconds(60),
   /** Total retry budget across all attempts. Maps to [RetrySettings.Builder.setTotalTimeout]. */
@@ -159,40 +105,36 @@ data class GcsStorageRetryConfig(
       .setReadTimeout(readTimeout.toMillis().toInt())
       .build()
 
+  /**
+   * Builds [StorageOptions] for Google Cloud Storage with this config's retry/timeout settings.
+   *
+   * @param projectId GCS project id, or `null` to let the library resolve it from the environment.
+   * @param useGrpc whether to use the gRPC transport instead of HTTP.
+   * @param openTelemetry [OpenTelemetry] instance for client metrics/traces, or `null`.
+   */
+  fun buildStorageOptions(
+    projectId: String? = null,
+    useGrpc: Boolean = false,
+    openTelemetry: OpenTelemetry? = null,
+  ): StorageOptions {
+    val builder: StorageOptions.Builder =
+      if (useGrpc) {
+        StorageOptions.grpc().setEnableGrpcClientMetrics(true)
+      } else {
+        StorageOptions.http().setTransportOptions(toHttpTransportOptions())
+      }
+    builder.setRetrySettings(toRetrySettings())
+    if (projectId != null) {
+      builder.setProjectId(projectId)
+    }
+    if (openTelemetry != null) {
+      builder.setOpenTelemetry(openTelemetry)
+    }
+    return builder.build()
+  }
+
   companion object {
     /** The resilient default configuration used for all callers unless overridden. */
     val DEFAULT = GcsStorageRetryConfig()
   }
-}
-
-/**
- * Builds [StorageOptions] for Google Cloud Storage with resilient retry/timeout settings applied by
- * default (see [GcsStorageRetryConfig]).
- *
- * @param projectId GCS project id, or `null` to let the library resolve it from the environment.
- * @param useGrpc whether to use the gRPC transport instead of HTTP. The HTTP transport read/connect
- *   timeouts only apply to the HTTP transport; on gRPC the per-attempt bound is the RPC timeout.
- * @param openTelemetry [OpenTelemetry] instance for client metrics/traces, or `null`.
- * @param retryConfig resilience configuration; defaults to [GcsStorageRetryConfig.DEFAULT].
- */
-fun buildGcsStorageOptions(
-  projectId: String? = null,
-  useGrpc: Boolean = false,
-  openTelemetry: OpenTelemetry? = null,
-  retryConfig: GcsStorageRetryConfig = GcsStorageRetryConfig.DEFAULT,
-): StorageOptions {
-  val builder: StorageOptions.Builder =
-    if (useGrpc) {
-      StorageOptions.grpc().setEnableGrpcClientMetrics(true)
-    } else {
-      StorageOptions.http().setTransportOptions(retryConfig.toHttpTransportOptions())
-    }
-  builder.setRetrySettings(retryConfig.toRetrySettings())
-  if (projectId != null) {
-    builder.setProjectId(projectId)
-  }
-  if (openTelemetry != null) {
-    builder.setOpenTelemetry(openTelemetry)
-  }
-  return builder.build()
 }

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cross-Media Measurement Authors
+// Copyright 2026 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,12 @@ import java.time.Duration
  * is distinct from [RetrySettings] RPC timeouts (`initialRpcTimeout`/`maxRpcTimeout`), which are
  * not enforced on the blocking Apiary HTTP read. [RetrySettings] here governs the retry budget
  * (`totalTimeout`, `maxAttempts`) and the jittered exponential backoff between attempts.
+ *
+ * ## Scope
+ * These [RetrySettings] and transport timeouts apply to ALL Storage operations (reads, writes, and
+ * metadata); the mid-stream resume-at-offset described above is the read-specific part, and the
+ * library's default retry strategy only retries idempotent writes, so widening the retry budget
+ * introduces no new double-write risk.
  *
  * ## Defaults
  * The defaults are deliberately generous so that legitimate slow reads are not broken, while still
@@ -98,9 +104,9 @@ data class GcsStorageRetryConfig(
     require(retryDelayMultiplier >= 1.0) {
       "retryDelayMultiplier must be >= 1.0, got $retryDelayMultiplier"
     }
-    require(totalTimeout >= readTimeout) {
-      "totalTimeout ($totalTimeout) must be >= readTimeout ($readTimeout) so at least one attempt " +
-        "fits in the budget"
+    require(totalTimeout >= connectTimeout.plus(readTimeout)) {
+      "totalTimeout ($totalTimeout) must be >= connectTimeout + readTimeout " +
+        "(${connectTimeout.plus(readTimeout)}) so at least one full attempt fits in the budget"
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptions.kt
@@ -22,8 +22,9 @@ import java.time.Duration
 
 /**
  * Resilience configuration -- retry budget and per-attempt timeouts -- applied to every
- * [StorageOptions] built by [buildStorageOptions]. Defaults are generous so legitimate slow reads
- * are not broken, and are overridable.
+ * [StorageOptions] built by [buildStorageOptions].
+ *
+ * Defaults are generous so legitimate slow reads are not broken, and are overridable.
  */
 data class GcsStorageRetryConfig(
   /**

--- a/src/main/kotlin/org/wfanet/measurement/storage/SelectedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/SelectedStorageClient.kt
@@ -14,12 +14,13 @@
 
 package org.wfanet.measurement.storage
 
-import com.google.cloud.storage.StorageOptions
 import com.google.protobuf.ByteString
 import java.io.File
 import java.net.URI
 import kotlinx.coroutines.flow.Flow
 import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
+import org.wfanet.measurement.gcloud.gcs.GcsStorageRetryConfig
+import org.wfanet.measurement.gcloud.gcs.buildGcsStorageOptions
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 
 // Data class to store parsed information
@@ -31,18 +32,22 @@ data class BlobUri(val scheme: String, val bucket: String, val key: String)
  * @param blobUri - the [BlobUri] from which a StorageClient can be built
  * @param rootDirectory - only needed for file system storage clients
  * @param projectId - optional if google cloud storage client needs require project id
+ * @param retryConfig - resilient retry/timeout configuration for Google Cloud Storage reads;
+ *   defaults to [GcsStorageRetryConfig.DEFAULT]
  */
 class SelectedStorageClient(
   private val blobUri: BlobUri,
   private val rootDirectory: File? = null,
   private val projectId: String? = null,
+  private val retryConfig: GcsStorageRetryConfig = GcsStorageRetryConfig.DEFAULT,
 ) : StorageClient, ConditionalOperationStorageClient {
 
   constructor(
     url: String,
     rootDirectory: File? = null,
     projectId: String? = null,
-  ) : this(parseBlobUri(url), rootDirectory, projectId)
+    retryConfig: GcsStorageRetryConfig = GcsStorageRetryConfig.DEFAULT,
+  ) : this(parseBlobUri(url), rootDirectory, projectId, retryConfig)
 
   val underlyingClient: ConditionalOperationStorageClient =
     when (blobUri.scheme) {
@@ -51,8 +56,7 @@ class SelectedStorageClient(
       }
       "gs" -> {
         val storageOptions =
-          if (projectId != null) StorageOptions.newBuilder().setProjectId(projectId).build()
-          else StorageOptions.getDefaultInstance()
+          buildGcsStorageOptions(projectId = projectId, retryConfig = retryConfig)
         GcsStorageClient(storageOptions.service, requireNotNull(blobUri.bucket))
       }
       "file" -> {

--- a/src/main/kotlin/org/wfanet/measurement/storage/SelectedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/storage/SelectedStorageClient.kt
@@ -20,7 +20,6 @@ import java.net.URI
 import kotlinx.coroutines.flow.Flow
 import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
 import org.wfanet.measurement.gcloud.gcs.GcsStorageRetryConfig
-import org.wfanet.measurement.gcloud.gcs.buildGcsStorageOptions
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 
 // Data class to store parsed information
@@ -55,8 +54,7 @@ class SelectedStorageClient(
         throw IllegalArgumentException("S3 is not currently supported")
       }
       "gs" -> {
-        val storageOptions =
-          buildGcsStorageOptions(projectId = projectId, retryConfig = retryConfig)
+        val storageOptions = retryConfig.buildStorageOptions(projectId = projectId)
         GcsStorageClient(storageOptions.service, requireNotNull(blobUri.bucket))
       }
       "file" -> {

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/BUILD.bazel
@@ -1,6 +1,21 @@
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 
 kt_jvm_test(
+    name = "GcsStorageOptionsTest",
+    srcs = ["GcsStorageOptionsTest.kt"],
+    test_class = "org.wfanet.measurement.gcloud.gcs.GcsStorageOptionsTest",
+    deps = [
+        "//imports/java/com/google/api/gax",
+        "//imports/java/com/google/cloud/storage",
+        "//imports/java/com/google/common/truth",
+        "//imports/java/org/junit",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/gcloud/gcs",
+    ],
+)
+
+kt_jvm_test(
     name = "GcsStorageClientTest",
     srcs = ["GcsStorageClientTest.kt"],
     tags = [

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
@@ -51,6 +51,7 @@ class GcsStorageOptionsTest {
     val config = GcsStorageRetryConfig.DEFAULT
     assertThat(config.connectTimeout).isEqualTo(Duration.ofSeconds(15))
     assertThat(config.readTimeout).isEqualTo(Duration.ofSeconds(30))
+    assertThat(config.rpcTimeout).isEqualTo(Duration.ofSeconds(60))
     assertThat(config.totalTimeout).isEqualTo(Duration.ofSeconds(180))
     assertThat(config.maxAttempts).isEqualTo(6)
     assertThat(config.initialRetryDelay).isEqualTo(Duration.ofSeconds(1))
@@ -66,6 +67,10 @@ class GcsStorageOptionsTest {
     assertThat(retrySettings.initialRetryDelayDuration).isEqualTo(Duration.ofSeconds(1))
     assertThat(retrySettings.maxRetryDelayDuration).isEqualTo(Duration.ofSeconds(32))
     assertThat(retrySettings.retryDelayMultiplier).isEqualTo(2.0)
+    // The RPC timeouts (the gRPC per-attempt deadline) come from rpcTimeout (60s), NOT from the
+    // HTTP readTimeout (30s).
+    assertThat(retrySettings.initialRpcTimeoutDuration).isEqualTo(Duration.ofSeconds(60))
+    assertThat(retrySettings.maxRpcTimeoutDuration).isEqualTo(Duration.ofSeconds(60))
   }
 
   @Test
@@ -101,6 +106,22 @@ class GcsStorageOptionsTest {
   fun `config rejects a non-positive read timeout`() {
     assertThrows(IllegalArgumentException::class.java) {
       GcsStorageRetryConfig(readTimeout = Duration.ZERO)
+    }
+  }
+
+  @Test
+  fun `config rejects a non-positive rpc timeout`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      GcsStorageRetryConfig(rpcTimeout = Duration.ZERO)
+    }
+  }
+
+  @Test
+  fun `config rejects a total timeout smaller than the rpc timeout`() {
+    // connect + read (15s + 30s = 45s) fits within total (50s), but the 60s default rpcTimeout does
+    // not, so a full gRPC attempt would not fit and the config must be rejected.
+    assertThrows(IllegalArgumentException::class.java) {
+      GcsStorageRetryConfig(totalTimeout = Duration.ofSeconds(50))
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
@@ -1,0 +1,368 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.gcloud.gcs
+
+import com.google.cloud.NoCredentials
+import com.google.cloud.http.HttpTransportOptions
+import com.google.cloud.storage.StorageOptions
+import com.google.common.truth.Truth.assertThat
+import java.io.IOException
+import java.io.InputStream
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.random.Random
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.flatten
+
+/**
+ * Tests for [GcsStorageRetryConfig] / [buildGcsStorageOptions].
+ *
+ * The read-path tests reproduce the production glitch (a Cloud Storage read that fails on a
+ * transient connection reset) against an in-process HTTP server ([FakeGcsServer]) that speaks just
+ * enough of the JSON API for [GcsStorageClient] to fetch and read a blob. The client is pointed at
+ * the fake via [StorageOptions.Builder.setHost] (mirroring
+ * `org.wfanet.measurement.gcloud.gcs.testing.StorageEmulator`).
+ */
+@RunWith(JUnit4::class)
+class GcsStorageOptionsTest {
+  @Test
+  fun `default config has resilient values`() {
+    val config = GcsStorageRetryConfig.DEFAULT
+    assertThat(config.connectTimeout).isEqualTo(Duration.ofSeconds(15))
+    assertThat(config.readTimeout).isEqualTo(Duration.ofSeconds(30))
+    assertThat(config.totalTimeout).isEqualTo(Duration.ofSeconds(180))
+    assertThat(config.maxAttempts).isEqualTo(6)
+    assertThat(config.initialRetryDelay).isEqualTo(Duration.ofSeconds(1))
+    assertThat(config.maxRetryDelay).isEqualTo(Duration.ofSeconds(32))
+    assertThat(config.retryDelayMultiplier).isEqualTo(2.0)
+  }
+
+  @Test
+  fun `toRetrySettings maps config values`() {
+    val retrySettings = GcsStorageRetryConfig.DEFAULT.toRetrySettings()
+    assertThat(retrySettings.totalTimeoutDuration).isEqualTo(Duration.ofSeconds(180))
+    assertThat(retrySettings.maxAttempts).isEqualTo(6)
+    assertThat(retrySettings.initialRetryDelayDuration).isEqualTo(Duration.ofSeconds(1))
+    assertThat(retrySettings.maxRetryDelayDuration).isEqualTo(Duration.ofSeconds(32))
+    assertThat(retrySettings.retryDelayMultiplier).isEqualTo(2.0)
+  }
+
+  @Test
+  fun `toHttpTransportOptions maps timeouts to millis`() {
+    val transportOptions = GcsStorageRetryConfig.DEFAULT.toHttpTransportOptions()
+    assertThat(transportOptions.connectTimeout).isEqualTo(15_000)
+    assertThat(transportOptions.readTimeout).isEqualTo(30_000)
+  }
+
+  @Test
+  fun `buildGcsStorageOptions applies resilient settings by default`() {
+    val options = buildGcsStorageOptions(projectId = "some-project")
+
+    assertThat(options.retrySettings.totalTimeoutDuration).isEqualTo(Duration.ofSeconds(180))
+    assertThat(options.retrySettings.maxAttempts).isEqualTo(6)
+    val transportOptions = options.transportOptions as HttpTransportOptions
+    assertThat(transportOptions.readTimeout).isEqualTo(30_000)
+    assertThat(transportOptions.connectTimeout).isEqualTo(15_000)
+  }
+
+  @Test
+  fun `buildGcsStorageOptions honors an overridden config`() {
+    val config =
+      GcsStorageRetryConfig.DEFAULT.copy(readTimeout = Duration.ofSeconds(5), maxAttempts = 3)
+
+    val options = buildGcsStorageOptions(projectId = "some-project", retryConfig = config)
+
+    assertThat(options.retrySettings.maxAttempts).isEqualTo(3)
+    assertThat((options.transportOptions as HttpTransportOptions).readTimeout).isEqualTo(5_000)
+  }
+
+  @Test
+  fun `config rejects a non-positive read timeout`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      GcsStorageRetryConfig(readTimeout = Duration.ZERO)
+    }
+  }
+
+  @Test
+  fun `config rejects a total timeout smaller than the read timeout`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      GcsStorageRetryConfig(
+        readTimeout = Duration.ofSeconds(30),
+        totalTimeout = Duration.ofSeconds(5),
+      )
+    }
+  }
+
+  @Test
+  fun `read resumes at offset after a mid-stream connection drop`() = runBlocking {
+    val content = Random(1).nextBytes(64 * 1024)
+    FakeGcsServer(content).use { server ->
+      // On the first media request, deliver a prefix then reset the connection (RST). The client
+      // must resume the download at the current offset via a Range request.
+      server.dropFirstAttemptAfterBytes = 16 * 1024
+
+      val client = gcsStorageClient(server.host, TEST_CONFIG)
+      val blob = checkNotNull(client.getBlob(OBJECT_NAME)) { "Blob not found" }
+
+      val read = blob.read().flatten().toByteArray()
+
+      // Full blob read back with correct bytes and no double-count.
+      assertThat(read).isEqualTo(content)
+      // The retried media request carried a Range starting exactly at the bytes delivered before
+      // the drop, proving resume-at-offset.
+      assertThat(server.observedMediaRangeStarts)
+        .containsExactly(0L, (16 * 1024).toLong())
+        .inOrder()
+    }
+  }
+
+  @Test
+  fun `read recovers from a stalled attempt via the per-attempt read timeout`() = runBlocking {
+    val content = Random(2).nextBytes(32 * 1024)
+    FakeGcsServer(content).use { server ->
+      // The first media request sends response headers then no body and holds the connection open.
+      // With a short per-attempt read timeout the client aborts that attempt and retries.
+      server.stallFirstAttemptMillis = 10_000
+
+      // Short read timeout keeps the test fast; a large read timeout with no retry would hang ~10s.
+      val config = TEST_CONFIG.copy(readTimeout = Duration.ofSeconds(2))
+      val client = gcsStorageClient(server.host, config)
+      val blob = checkNotNull(client.getBlob(OBJECT_NAME)) { "Blob not found" }
+
+      val startNanos = System.nanoTime()
+      val read = blob.read().flatten().toByteArray()
+      val elapsed = Duration.ofNanos(System.nanoTime() - startNanos)
+
+      assertThat(read).isEqualTo(content)
+      // The stalled attempt was aborted by the read timeout (~2s) and the retry succeeded, rather
+      // than waiting the full 10s stall.
+      assertThat(elapsed).isLessThan(Duration.ofSeconds(8))
+      assertThat(server.mediaRequestCount).isAtLeast(2)
+    }
+  }
+
+  private fun gcsStorageClient(host: String, config: GcsStorageRetryConfig): GcsStorageClient {
+    val storageOptions =
+      StorageOptions.http()
+        .setHost(host)
+        .setProjectId("fake-project")
+        .setCredentials(NoCredentials.getInstance())
+        .setTransportOptions(config.toHttpTransportOptions())
+        .setRetrySettings(config.toRetrySettings())
+        .build()
+    return GcsStorageClient(storageOptions.service, BUCKET)
+  }
+
+  /**
+   * Minimal in-process Cloud Storage HTTP endpoint backed by a raw [ServerSocket], used to inject
+   * controllable connection failures into the read path.
+   *
+   * Each request is served on its own thread. A request whose query contains `alt=media` is treated
+   * as a media download; anything else is treated as an object-metadata fetch.
+   */
+  private class FakeGcsServer(private val objectBytes: ByteArray) : AutoCloseable {
+    private val serverSocket = ServerSocket(0)
+    private val mediaAttempts = AtomicInteger(0)
+    private val rangeStarts = CopyOnWriteArrayList<Long>()
+
+    /** If `>= 0`, the first media attempt sends this many bytes then resets the connection. */
+    @Volatile var dropFirstAttemptAfterBytes: Int = -1
+
+    /** If `> 0`, the first media attempt sends headers then stalls for this many millis. */
+    @Volatile var stallFirstAttemptMillis: Long = 0
+
+    val host: String
+      get() = "http://localhost:${serverSocket.localPort}"
+
+    /** Range start offset observed for each media request, in arrival order. */
+    val observedMediaRangeStarts: List<Long>
+      get() = rangeStarts.toList()
+
+    val mediaRequestCount: Int
+      get() = mediaAttempts.get()
+
+    init {
+      thread(isDaemon = true, name = "fake-gcs-accept") { acceptLoop() }
+    }
+
+    private fun acceptLoop() {
+      while (!serverSocket.isClosed) {
+        val socket =
+          try {
+            serverSocket.accept()
+          } catch (e: IOException) {
+            return // Socket closed.
+          }
+        thread(isDaemon = true, name = "fake-gcs-conn") { handle(socket) }
+      }
+    }
+
+    private fun handle(socket: Socket) {
+      try {
+        socket.tcpNoDelay = true
+        val requestHead = readRequestHead(socket.getInputStream()) ?: return
+        val requestLine = requestHead.substringBefore("\r\n")
+        if (requestLine.contains("alt=media")) {
+          val rangeStart = parseRangeStart(requestHead)
+          rangeStarts.add(rangeStart)
+          val attempt = mediaAttempts.incrementAndGet()
+          when {
+            attempt == 1 && stallFirstAttemptMillis > 0 ->
+              serveHeadersThenStall(socket, rangeStart, stallFirstAttemptMillis)
+            attempt == 1 && dropFirstAttemptAfterBytes >= 0 ->
+              serveDropThenReset(socket, rangeStart, dropFirstAttemptAfterBytes)
+            else -> serveMedia(socket, rangeStart)
+          }
+        } else {
+          serveMetadata(socket)
+        }
+      } catch (e: IOException) {
+        // Client went away; nothing to do.
+      } finally {
+        try {
+          socket.close()
+        } catch (e: IOException) {
+          // Ignore.
+        }
+      }
+    }
+
+    private fun serveMetadata(socket: Socket) {
+      val json =
+        """{"kind":"storage#object","bucket":"$BUCKET","name":"$OBJECT_NAME","generation":"1",""" +
+          """"metageneration":"1","contentType":"application/octet-stream",""" +
+          """"size":"${objectBytes.size}","timeCreated":"2024-01-01T00:00:00.000Z",""" +
+          """"updated":"2024-01-01T00:00:00.000Z"}"""
+      val body = json.toByteArray(StandardCharsets.UTF_8)
+      val out = socket.getOutputStream()
+      out.write(
+        ("HTTP/1.1 200 OK\r\n" +
+            "Content-Type: application/json; charset=UTF-8\r\n" +
+            "Content-Length: ${body.size}\r\n" +
+            "Connection: close\r\n\r\n")
+          .toByteArray(StandardCharsets.UTF_8)
+      )
+      out.write(body)
+      out.flush()
+    }
+
+    private fun serveMedia(socket: Socket, rangeStart: Long) {
+      val start = rangeStart.toInt().coerceIn(0, objectBytes.size)
+      val slice = objectBytes.copyOfRange(start, objectBytes.size)
+      val out = socket.getOutputStream()
+      val statusLine = if (start > 0) "HTTP/1.1 206 Partial Content" else "HTTP/1.1 200 OK"
+      val headers = StringBuilder()
+      headers.append("$statusLine\r\n")
+      headers.append("Content-Type: application/octet-stream\r\n")
+      headers.append("Content-Length: ${slice.size}\r\n")
+      if (start > 0) {
+        headers.append(
+          "Content-Range: bytes $start-${objectBytes.size - 1}/${objectBytes.size}\r\n"
+        )
+      }
+      headers.append("Connection: close\r\n\r\n")
+      out.write(headers.toString().toByteArray(StandardCharsets.UTF_8))
+      out.write(slice)
+      out.flush()
+    }
+
+    private fun serveDropThenReset(socket: Socket, rangeStart: Long, partialLen: Int) {
+      val start = rangeStart.toInt().coerceIn(0, objectBytes.size)
+      val remaining = objectBytes.size - start
+      val out = socket.getOutputStream()
+      // Declare the full remaining length but only send a prefix, then abort with a TCP RST so the
+      // client observes a mid-stream connection reset (a retryable SocketException).
+      out.write(
+        ("HTTP/1.1 200 OK\r\n" +
+            "Content-Type: application/octet-stream\r\n" +
+            "Content-Length: $remaining\r\n" +
+            "Connection: close\r\n\r\n")
+          .toByteArray(StandardCharsets.UTF_8)
+      )
+      out.write(objectBytes, start, partialLen.coerceAtMost(remaining))
+      out.flush()
+      socket.setSoLinger(true, 0)
+      socket.close()
+    }
+
+    private fun serveHeadersThenStall(socket: Socket, rangeStart: Long, stallMillis: Long) {
+      val start = rangeStart.toInt().coerceIn(0, objectBytes.size)
+      val remaining = objectBytes.size - start
+      val out = socket.getOutputStream()
+      out.write(
+        ("HTTP/1.1 200 OK\r\n" +
+            "Content-Type: application/octet-stream\r\n" +
+            "Content-Length: $remaining\r\n" +
+            "Connection: close\r\n\r\n")
+          .toByteArray(StandardCharsets.UTF_8)
+      )
+      out.flush()
+      // Send no body and hold the connection open so the client's socket read stalls.
+      Thread.sleep(stallMillis)
+    }
+
+    private fun readRequestHead(input: InputStream): String? {
+      val builder = StringBuilder()
+      while (true) {
+        val c = input.read()
+        if (c == -1) {
+          return builder.ifEmpty { null }?.toString()
+        }
+        builder.append(c.toChar())
+        if (builder.endsWith("\r\n\r\n")) {
+          return builder.toString()
+        }
+      }
+    }
+
+    private fun parseRangeStart(requestHead: String): Long {
+      val rangeLine =
+        requestHead.lineSequence().firstOrNull { it.startsWith("Range:", ignoreCase = true) }
+          ?: return 0L
+      val spec = rangeLine.substringAfter("bytes=", "").trim()
+      return spec.substringBefore("-", "").trim().toLongOrNull() ?: 0L
+    }
+
+    override fun close() {
+      serverSocket.close()
+    }
+  }
+
+  companion object {
+    private const val BUCKET = "test-bucket"
+    private const val OBJECT_NAME = "test-object"
+
+    /** Fast but resilient config for read-path tests. */
+    private val TEST_CONFIG =
+      GcsStorageRetryConfig(
+        connectTimeout = Duration.ofSeconds(5),
+        readTimeout = Duration.ofSeconds(10),
+        totalTimeout = Duration.ofSeconds(60),
+        maxAttempts = 5,
+        initialRetryDelay = Duration.ofMillis(100),
+        maxRetryDelay = Duration.ofSeconds(1),
+        retryDelayMultiplier = 2.0,
+      )
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
@@ -36,7 +36,7 @@ import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.flatten
 
 /**
- * Tests for [GcsStorageRetryConfig] / [buildGcsStorageOptions].
+ * Tests for [GcsStorageRetryConfig] and [GcsStorageRetryConfig.buildStorageOptions].
  *
  * The read-path tests reproduce the production glitch (a Cloud Storage read that fails on a
  * transient connection reset) against an in-process HTTP server ([FakeGcsServer]) that speaks just
@@ -81,8 +81,8 @@ class GcsStorageOptionsTest {
   }
 
   @Test
-  fun `buildGcsStorageOptions applies resilient settings by default`() {
-    val options = buildGcsStorageOptions(projectId = "some-project")
+  fun `buildStorageOptions applies resilient settings by default`() {
+    val options = GcsStorageRetryConfig.DEFAULT.buildStorageOptions(projectId = "some-project")
 
     assertThat(options.retrySettings.totalTimeoutDuration).isEqualTo(Duration.ofSeconds(180))
     assertThat(options.retrySettings.maxAttempts).isEqualTo(6)
@@ -92,11 +92,11 @@ class GcsStorageOptionsTest {
   }
 
   @Test
-  fun `buildGcsStorageOptions honors an overridden config`() {
+  fun `buildStorageOptions honors an overridden config`() {
     val config =
       GcsStorageRetryConfig.DEFAULT.copy(readTimeout = Duration.ofSeconds(5), maxAttempts = 3)
 
-    val options = buildGcsStorageOptions(projectId = "some-project", retryConfig = config)
+    val options = config.buildStorageOptions(projectId = "some-project")
 
     assertThat(options.retrySettings.maxAttempts).isEqualTo(3)
     assertThat((options.transportOptions as HttpTransportOptions).readTimeout).isEqualTo(5_000)

--- a/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/gcloud/gcs/GcsStorageOptionsTest.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cross-Media Measurement Authors
+// Copyright 2026 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,13 +105,23 @@ class GcsStorageOptionsTest {
   }
 
   @Test
-  fun `config rejects a total timeout smaller than the read timeout`() {
+  fun `config rejects a total timeout smaller than connect plus read timeout`() {
+    // total (40s) exceeds the read timeout (30s) but is still below connect + read (15s + 30s), so
+    // it does not leave room for one full attempt and must be rejected.
     assertThrows(IllegalArgumentException::class.java) {
       GcsStorageRetryConfig(
+        connectTimeout = Duration.ofSeconds(15),
         readTimeout = Duration.ofSeconds(30),
-        totalTimeout = Duration.ofSeconds(5),
+        totalTimeout = Duration.ofSeconds(40),
       )
     }
+  }
+
+  @Test
+  fun `default config satisfies the connect plus read timeout budget`() {
+    // Constructing the default config must not throw: 180s >= 15s + 30s.
+    val config = GcsStorageRetryConfig()
+    assertThat(config.totalTimeout).isAtLeast(config.connectTimeout.plus(config.readTimeout))
   }
 
   @Test
@@ -150,14 +160,11 @@ class GcsStorageOptionsTest {
       val client = gcsStorageClient(server.host, config)
       val blob = checkNotNull(client.getBlob(OBJECT_NAME)) { "Blob not found" }
 
-      val startNanos = System.nanoTime()
       val read = blob.read().flatten().toByteArray()
-      val elapsed = Duration.ofNanos(System.nanoTime() - startNanos)
 
       assertThat(read).isEqualTo(content)
-      // The stalled attempt was aborted by the read timeout (~2s) and the retry succeeded, rather
-      // than waiting the full 10s stall.
-      assertThat(elapsed).isLessThan(Duration.ofSeconds(8))
+      // More than one media request proves the stalled first attempt was aborted by the read
+      // timeout and a retry fired (rather than blocking on the single stalled attempt).
       assertThat(server.mediaRequestCount).isAtLeast(2)
     }
   }

--- a/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/storage/BUILD.bazel
@@ -22,6 +22,7 @@ kt_jvm_test(
         "//imports/java/com/google/common/truth",
         "//imports/java/org/junit",
         "//imports/kotlin/kotlin/test",
+        "//src/main/kotlin/org/wfanet/measurement/gcloud/gcs",
         "//src/main/kotlin/org/wfanet/measurement/storage:selected_storage_client",
         "//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/storage/SelectedStorageClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/storage/SelectedStorageClientTest.kt
@@ -19,6 +19,7 @@ package org.wfanet.measurement.storage
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.kotlin.toByteStringUtf8
 import java.nio.file.Files
+import java.time.Duration
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -27,6 +28,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.flatten
+import org.wfanet.measurement.gcloud.gcs.GcsStorageRetryConfig
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 
 @RunWith(JUnit4::class)
@@ -41,6 +43,15 @@ class SelectedStorageClientTest {
   fun `constructor for gs scheme does not throw error`() {
     val blobUri = BlobUri("gs", "bucket", "path/to/file")
     SelectedStorageClient(blobUri)
+  }
+
+  @Test
+  fun `constructor for gs scheme accepts a custom retry config`() {
+    val blobUri = BlobUri("gs", "bucket", "path/to/file")
+    SelectedStorageClient(
+      blobUri,
+      retryConfig = GcsStorageRetryConfig.DEFAULT.copy(readTimeout = Duration.ofSeconds(10)),
+    )
   }
 
   @Test


### PR DESCRIPTION
## Why
  
  Cloud Storage reads in downstream services (observed in the EDPA Results-Fulfiller)
  intermittently fail on transient connection resets — `com.google.cloud.storage.StorageException:
  Broken pipe` and `Remote host terminated the handshake`, thrown from
  `BaseStorageReadChannel.read`. Root cause is client configuration, not infrastructure:
  
  - `StorageOptions` was built with **no transport socket read timeout** and the
    google-cloud-storage **library-default retry budget** (`totalTimeout = 50s`,
    `maxAttempts = 6`).
  - Production `RetryContext$RetryBudgetExhausted` traces show reads failing after
    **`attempts: 1`**: a single stalled/slow socket read consumes the whole 50s budget before
    a second attempt can start, because nothing bounds an individual stalled read.
  - The google-cloud-storage read channel **already resumes mid-stream at the current offset**
    via a `Range` request (`ApiaryUnbufferedReadableByteChannel` tracks `position` and re-opens
    with `withNewBeginOffset`) — but with the default budget it never gets to run. 
    
  ## What bounds a stalled read (the key knob)
  
  On the HTTP/Apiary transport the read is aborted by the **transport socket read timeout**
  (`HttpTransportOptions.setReadTimeout` → `HttpRequest.setReadTimeout` → `HttpURLConnection`
  `SO_TIMEOUT`), applied via `StorageOptions.setTransportOptions` — **not** by the
  `RetrySettings` RPC timeouts, which are not enforced on the blocking Apiary read.
  `RetrySettings` governs only the retry budget (`totalTimeout`, `maxAttempts`) and backoff.

  ## Changes

  - New `GcsStorageOptions.kt`: a validated `GcsStorageRetryConfig` and a single
    `buildGcsStorageOptions(...)` factory — the one place `StorageOptions` is now built.
  - Resilient **defaults**, deliberately generous so legitimate slow reads are not broken:
    - per-attempt `readTimeout = 30s`, `connectTimeout = 15s` (HTTP transport);
    - `totalTimeout = 180s` (was 50s) so **several** bounded attempts fit, each resuming at
      the current offset; `maxAttempts = 6`, jittered exponential backoff (1s → 32s).
    - Fully overridable via the optional `retryConfig` parameter, so a caller (e.g. the
      Results-Fulfiller) can tune tighter.
  - `SelectedStorageClient` and `GcsFromFlags` route through the factory. All public APIs stay
    **backward-compatible** (new parameters are optional/defaulted).

  ## Testing

  - **Reproduces the actual glitch:** a raw `ServerSocket` sends 16 KiB then a TCP RST
    mid-download; the test asserts the full blob reads back byte-identical **and**
    `observedMediaRangeStarts == [0, 16384]` — i.e. the client genuinely resumes via
    `Range: bytes=16384-` with no double-count.
  - **Stalled-read test:** first attempt stalls; the per-attempt read timeout aborts it and the
    retry succeeds (fast, not after the full stall).
  - Config-mapping/validation unit tests and a backward-compat test for a custom `retryConfig`.
  - Existing `SelectedStorageClientTest` and `GcsStorageClientTest` pass (no regression).
  - `ktfmt 0.54 --google-style` clean.

Issue: https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/4286