### PR TITLE
fix: make AwsKmsClient associated-data encoding configurable and deprecate it

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/aws/kms/AwsKmsClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/kms/AwsKmsClient.kt
@@ -26,16 +26,59 @@ import software.amazon.awssdk.services.kms.KmsClient as SdkKmsClient
 import software.amazon.awssdk.services.kms.model.DecryptRequest
 import software.amazon.awssdk.services.kms.model.EncryptRequest
 import software.amazon.awssdk.services.kms.model.KmsException
+import software.amazon.awssdk.utils.BinaryUtils
+
+/**
+ * How associated data is encoded into the AWS KMS encryption context value.
+ *
+ * The encryption context is authenticated by AWS KMS, so the encoding used at encrypt time must
+ * match the encoding used at decrypt time, including across different client implementations.
+ */
+enum class AssociatedDataEncoding {
+  /**
+   * Lowercase hex, byte-for-byte identical to upstream Tink's
+   * `com.google.crypto.tink.integration.awskms.AwsKmsAead` (which uses
+   * `software.amazon.awssdk.utils.BinaryUtils.toHex`). Use this for interoperability with the
+   * upstream `tink-awskms` client.
+   */
+  HEX,
+
+  /**
+   * Base64. This was the original encoding used by this class; it is NOT interoperable with
+   * upstream Tink. Retained only to read data written by earlier versions of this client.
+   */
+  BASE64,
+}
+
+/** Encodes [associatedData] for the KMS encryption context using [encoding]. */
+internal fun encodeAssociatedData(
+  associatedData: ByteArray,
+  encoding: AssociatedDataEncoding,
+): String =
+  when (encoding) {
+    AssociatedDataEncoding.HEX -> BinaryUtils.toHex(associatedData)
+    AssociatedDataEncoding.BASE64 -> Base64.getEncoder().encodeToString(associatedData)
+  }
 
 /**
  * A Tink [KmsClient] implementation for AWS KMS using AWS SDK v2.
  *
- * This avoids the `tink-awskms` library which depends on AWS SDK v1, allowing usage in projects
- * that standardize on AWS SDK v2.
- *
  * @param credentialsProvider The [AwsCredentialsProvider] to use for authenticating with AWS KMS.
+ * @param associatedDataEncoding How associated data is encoded into the KMS encryption context.
+ *   Defaults to [AssociatedDataEncoding.HEX] to match upstream Tink.
+ * @deprecated Superseded by the upstream `com.google.crypto.tink.integration.awskms.AwsKmsClient`
+ *   (`tink-awskms` >= 2.0.0), which also targets AWS SDK v2. This class remains temporarily until
+ *   the Tink version upgrade that pulls in `tink-awskms` lands; construct it with
+ *   [AssociatedDataEncoding.HEX] (the default) so its output is interoperable with that client.
  */
-class AwsKmsClient(private val credentialsProvider: AwsCredentialsProvider) : KmsClient {
+@Deprecated(
+  "Superseded by upstream com.google.crypto.tink.integration.awskms.AwsKmsClient (tink-awskms). " +
+    "Temporary until the Tink upgrade lands; use AssociatedDataEncoding.HEX for interoperability."
+)
+class AwsKmsClient(
+  private val credentialsProvider: AwsCredentialsProvider,
+  private val associatedDataEncoding: AssociatedDataEncoding = AssociatedDataEncoding.HEX,
+) : KmsClient {
 
   override fun doesSupport(keyUri: String?): Boolean {
     return keyUri != null && keyUri.lowercase(Locale.US).startsWith(KEY_URI_PREFIX)
@@ -80,7 +123,7 @@ class AwsKmsClient(private val credentialsProvider: AwsCredentialsProvider) : Km
         throw GeneralSecurityException("Cannot initialize AWS KMS client", e)
       }
 
-    return AwsKmsAead(kmsClient, keyArn)
+    return AwsKmsAead(kmsClient, keyArn, associatedDataEncoding)
   }
 
   companion object {
@@ -100,10 +143,15 @@ class AwsKmsClient(private val credentialsProvider: AwsCredentialsProvider) : Km
 /**
  * An [Aead] implementation backed by AWS KMS using AWS SDK v2.
  *
- * Encryption context with `associatedData` (Base64-encoded) is included when [associatedData] is
- * non-null and non-empty, matching the behavior of Tink's `AwsKmsAead`.
+ * When [associatedData] is non-null and non-empty, it is added to the KMS encryption context under
+ * the key `associatedData`, encoded per [associatedDataEncoding]. With [AssociatedDataEncoding.HEX]
+ * this matches upstream Tink's `AwsKmsAead`.
  */
-private class AwsKmsAead(private val kmsClient: SdkKmsClient, private val keyArn: String) : Aead {
+internal class AwsKmsAead(
+  private val kmsClient: SdkKmsClient,
+  private val keyArn: String,
+  private val associatedDataEncoding: AssociatedDataEncoding,
+) : Aead {
 
   override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?): ByteArray {
     try {
@@ -114,7 +162,10 @@ private class AwsKmsAead(private val kmsClient: SdkKmsClient, private val keyArn
             plaintext(SdkBytes.fromByteArray(plaintext))
             if (associatedData != null && associatedData.isNotEmpty()) {
               encryptionContext(
-                mapOf(ASSOCIATED_DATA_KEY to Base64.getEncoder().encodeToString(associatedData))
+                mapOf(
+                  ASSOCIATED_DATA_KEY to
+                    encodeAssociatedData(associatedData, associatedDataEncoding)
+                )
               )
             }
           }
@@ -134,7 +185,10 @@ private class AwsKmsAead(private val kmsClient: SdkKmsClient, private val keyArn
             ciphertextBlob(SdkBytes.fromByteArray(ciphertext))
             if (associatedData != null && associatedData.isNotEmpty()) {
               encryptionContext(
-                mapOf(ASSOCIATED_DATA_KEY to Base64.getEncoder().encodeToString(associatedData))
+                mapOf(
+                  ASSOCIATED_DATA_KEY to
+                    encodeAssociatedData(associatedData, associatedDataEncoding)
+                )
               )
             }
           }

--- a/src/main/kotlin/org/wfanet/measurement/aws/kms/AwsKmsClientFactory.kt
+++ b/src/main/kotlin/org/wfanet/measurement/aws/kms/AwsKmsClientFactory.kt
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@file:Suppress(
+  "DEPRECATION"
+) // Transitional: AwsKmsClient is deprecated in favor of upstream tink-awskms.
+
 package org.wfanet.measurement.aws.kms
 
 import com.google.crypto.tink.KmsClient

--- a/src/main/kotlin/org/wfanet/measurement/gcloud/kms/GCloudToAwsKmsClientFactory.kt
+++ b/src/main/kotlin/org/wfanet/measurement/gcloud/kms/GCloudToAwsKmsClientFactory.kt
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@file:Suppress(
+  "DEPRECATION"
+) // Transitional: AwsKmsClient is deprecated in favor of upstream tink-awskms.
+
 package org.wfanet.measurement.gcloud.kms
 
 import com.google.auth.oauth2.GoogleCredentials

--- a/src/test/kotlin/org/wfanet/measurement/aws/kms/AwsKmsClientFactoryTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/aws/kms/AwsKmsClientFactoryTest.kt
@@ -12,24 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@file:Suppress("DEPRECATION") // Exercises the deprecated AwsKmsClient during its transition period.
+
 package org.wfanet.measurement.aws.kms
 
 import com.google.common.truth.Truth.assertThat
 import java.security.GeneralSecurityException
+import java.util.Base64
 import kotlin.test.assertFailsWith
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.kms.KmsClient as SdkKmsClient
+import software.amazon.awssdk.services.kms.model.DecryptRequest
+import software.amazon.awssdk.services.kms.model.DecryptResponse
+import software.amazon.awssdk.services.kms.model.EncryptRequest
+import software.amazon.awssdk.services.kms.model.EncryptResponse
+import software.amazon.awssdk.utils.BinaryUtils
 
 private const val AWS_KMS_KEY_URI = "aws-kms://arn:aws:kms:us-east-1:123456789012:key/test-key-id"
+private const val KEY_ARN = "arn:aws:kms:us-east-1:123456789012:key/test-key-id"
 private const val GCP_KMS_KEY_URI = "gcp-kms://projects/test/locations/us/keyRings/kr/cryptoKeys/ck"
 private const val FAKE_KMS_KEY_URI = "fake-kms://key1"
 private const val INVALID_ARN_KEY_URI = "aws-kms://invalid-arn"
 
-/** Tests for [AwsKmsClient]. */
+/** Tests for [AwsKmsClient], [AwsKmsAead], and [encodeAssociatedData]. */
 @RunWith(JUnit4::class)
 class AwsKmsClientFactoryTest {
   private lateinit var kmsClient: AwsKmsClient
@@ -74,5 +87,113 @@ class AwsKmsClientFactoryTest {
   @Test
   fun `getAead throws GeneralSecurityException for invalid ARN`() {
     assertFailsWith<GeneralSecurityException> { kmsClient.getAead(INVALID_ARN_KEY_URI) }
+  }
+
+  @Test
+  fun `encodeAssociatedData HEX produces lowercase hex`() {
+    val bytes = byteArrayOf(0x00, 0x01, 0x0f, 0x10, 0xab.toByte(), 0xff.toByte())
+    assertThat(encodeAssociatedData(bytes, AssociatedDataEncoding.HEX)).isEqualTo("00010f10abff")
+  }
+
+  @Test
+  fun `encodeAssociatedData HEX matches AWS SDK BinaryUtils (upstream Tink encoding)`() {
+    val bytes = "some-blob-key/2026-03-13/data".toByteArray(Charsets.UTF_8)
+    assertThat(encodeAssociatedData(bytes, AssociatedDataEncoding.HEX))
+      .isEqualTo(BinaryUtils.toHex(bytes))
+  }
+
+  @Test
+  fun `encodeAssociatedData BASE64 produces base64`() {
+    val bytes = "some-blob-key".toByteArray(Charsets.UTF_8)
+    assertThat(encodeAssociatedData(bytes, AssociatedDataEncoding.BASE64))
+      .isEqualTo(Base64.getEncoder().encodeToString(bytes))
+  }
+
+  @Test
+  fun `HEX and BASE64 encodings differ for the same input`() {
+    val bytes = "some-blob-key".toByteArray(Charsets.UTF_8)
+    assertThat(encodeAssociatedData(bytes, AssociatedDataEncoding.HEX))
+      .isNotEqualTo(encodeAssociatedData(bytes, AssociatedDataEncoding.BASE64))
+  }
+
+  @Test
+  fun `AwsKmsAead encrypt uses hex encryption context in HEX mode`() {
+    val mockKms = Mockito.mock(SdkKmsClient::class.java)
+    Mockito.`when`(mockKms.encrypt(Mockito.any(EncryptRequest::class.java)))
+      .thenReturn(
+        EncryptResponse.builder()
+          .ciphertextBlob(SdkBytes.fromByteArray(byteArrayOf(1, 2, 3)))
+          .build()
+      )
+    val aead = AwsKmsAead(mockKms, KEY_ARN, AssociatedDataEncoding.HEX)
+    val associatedData = "blob-key".toByteArray(Charsets.UTF_8)
+
+    aead.encrypt("plaintext".toByteArray(Charsets.UTF_8), associatedData)
+
+    val captor = ArgumentCaptor.forClass(EncryptRequest::class.java)
+    Mockito.verify(mockKms).encrypt(captor.capture())
+    assertThat(captor.value.encryptionContext())
+      .containsExactly("associatedData", BinaryUtils.toHex(associatedData))
+  }
+
+  @Test
+  fun `AwsKmsAead encrypt uses base64 encryption context in BASE64 mode`() {
+    val mockKms = Mockito.mock(SdkKmsClient::class.java)
+    Mockito.`when`(mockKms.encrypt(Mockito.any(EncryptRequest::class.java)))
+      .thenReturn(
+        EncryptResponse.builder()
+          .ciphertextBlob(SdkBytes.fromByteArray(byteArrayOf(1, 2, 3)))
+          .build()
+      )
+    val aead = AwsKmsAead(mockKms, KEY_ARN, AssociatedDataEncoding.BASE64)
+    val associatedData = "blob-key".toByteArray(Charsets.UTF_8)
+
+    aead.encrypt("plaintext".toByteArray(Charsets.UTF_8), associatedData)
+
+    val captor = ArgumentCaptor.forClass(EncryptRequest::class.java)
+    Mockito.verify(mockKms).encrypt(captor.capture())
+    assertThat(captor.value.encryptionContext())
+      .containsExactly("associatedData", Base64.getEncoder().encodeToString(associatedData))
+  }
+
+  @Test
+  fun `AwsKmsAead encrypt sends no encryption context when associated data is empty`() {
+    val mockKms = Mockito.mock(SdkKmsClient::class.java)
+    Mockito.`when`(mockKms.encrypt(Mockito.any(EncryptRequest::class.java)))
+      .thenReturn(
+        EncryptResponse.builder()
+          .ciphertextBlob(SdkBytes.fromByteArray(byteArrayOf(1, 2, 3)))
+          .build()
+      )
+    val aead = AwsKmsAead(mockKms, KEY_ARN, AssociatedDataEncoding.HEX)
+
+    aead.encrypt("plaintext".toByteArray(Charsets.UTF_8), ByteArray(0))
+
+    val captor = ArgumentCaptor.forClass(EncryptRequest::class.java)
+    Mockito.verify(mockKms).encrypt(captor.capture())
+    assertThat(captor.value.hasEncryptionContext()).isFalse()
+  }
+
+  @Test
+  fun `AwsKmsAead decrypt uses hex encryption context in HEX mode`() {
+    val mockKms = Mockito.mock(SdkKmsClient::class.java)
+    val plaintext = "plaintext".toByteArray(Charsets.UTF_8)
+    Mockito.`when`(mockKms.decrypt(Mockito.any(DecryptRequest::class.java)))
+      .thenReturn(
+        DecryptResponse.builder()
+          .keyId(KEY_ARN)
+          .plaintext(SdkBytes.fromByteArray(plaintext))
+          .build()
+      )
+    val aead = AwsKmsAead(mockKms, KEY_ARN, AssociatedDataEncoding.HEX)
+    val associatedData = "blob-key".toByteArray(Charsets.UTF_8)
+
+    val result = aead.decrypt(byteArrayOf(1, 2, 3), associatedData)
+
+    assertThat(result).isEqualTo(plaintext)
+    val captor = ArgumentCaptor.forClass(DecryptRequest::class.java)
+    Mockito.verify(mockKms).decrypt(captor.capture())
+    assertThat(captor.value.encryptionContext())
+      .containsExactly("associatedData", BinaryUtils.toHex(associatedData))
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/aws/kms/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/aws/kms/BUILD.bazel
@@ -3,12 +3,14 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 kt_jvm_test(
     name = "AwsKmsClientFactoryTest",
     srcs = ["AwsKmsClientFactoryTest.kt"],
+    associates = ["//src/main/kotlin/org/wfanet/measurement/aws/kms:aws_kms_client_factory"],
     test_class = "org.wfanet.measurement.aws.kms.AwsKmsClientFactoryTest",
     deps = [
         "//imports/java/com/google/common/truth",
         "//imports/java/org/junit",
+        "//imports/java/org/mockito",
         "//imports/java/software/amazon/awssdk/auth",
+        "//imports/java/software/amazon/awssdk/services/kms",
         "//imports/kotlin/kotlin/test",
-        "//src/main/kotlin/org/wfanet/measurement/aws/kms:aws_kms_client_factory",
     ],
 )


### PR DESCRIPTION
The custom AWS KMS `AwsKmsClient` hardcoded Base64 for the KMS encryption context, which is NOT interoperable with stock Tink (which uses hex via `BinaryUtils.toHex`). This adds an `AssociatedDataEncoding` constructor option — defaulting to `HEX` to match upstream Tink, with `BASE64` retained for reading any data written by earlier versions — and marks the class `@Deprecated`. No existing data relied on the Base64 encoding.

This is a temporary, low-risk workaround to make AWS KMS output Tink-interoperable now, ahead of the larger Tink version upgrade that adopts the upstream `tink-awskms` client and removes this custom class. That upgrade is tracked by common-jvm #399 and cross-media-measurement #4299, which are blocked on the Tink-upgrade issues (e.g. #271); once they land, this class is removed and this change is no longer needed.

Issue: world-federation-of-advertisers/cross-media-measurement#4298